### PR TITLE
ci: add CI/CD workflows and bump to 0.7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
+  request-copilot-review:
+    name: Request Copilot Review
+    if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot as reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set +e
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=copilot-pull-request-reviewer"
+          status=$?
+          if [ $status -ne 0 ]; then
+            echo "::warning::Failed to request Copilot review. Ensure Copilot code review is enabled for this repository (Settings → Code & automation → Code review)."
+          fi
+          exit 0

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,67 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Pack & Publish
+    runs-on: ubuntu-latest
+    environment: nuget
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Pack
+        run: |
+          mkdir -p ./artifacts
+          dotnet pack src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj \
+            --configuration Release --no-build --output ./artifacts
+          dotnet pack src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj \
+            --configuration Release --no-build --output ./artifacts
+          dotnet pack src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj \
+            --configuration Release --no-build --output ./artifacts
+          dotnet pack src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj \
+            --configuration Release --no-build --output ./artifacts
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkgs
+          path: ./artifacts/*.nupkg
+
+      - name: Publish to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "${NUGET_API_KEY}" ]; then
+            echo "::error::NUGET_API_KEY secret is not set."
+            exit 1
+          fi
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "${NUGET_API_KEY}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,43 @@
+name: Tag on Merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from csproj
+        id: version
+        run: |
+          VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read <Version> from src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Create and push tag if missing
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG="v${VERSION}"
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists, skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+          echo "Created and pushed tag ${TAG}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.7.1 (2026-05-02)
+
+### Added
+
+- GitHub Actions CI/CD workflows under `.github/workflows/`:
+  - `ci.yml` — build & test on .NET 8 and .NET 10 for every PR; requests
+    GitHub Copilot as a reviewer on PR open/reopen/ready_for_review.
+  - `tag-on-merge.yml` — on merge to `main`, reads `<Version>` from
+    `Idevs.Net.CoreLib.csproj` and creates an annotated `v{version}` tag
+    (idempotent; skips if the tag already exists).
+  - `publish-nuget.yml` — on `v*` tag push, packs all four public projects
+    and publishes them to nuget.org via the `nuget` deployment environment
+    (`--skip-duplicate`). Uploads `.nupkg` artifacts for traceability.
+
 ## 0.7.0 (2026-05-02)
 
 ### Breaking Changes

--- a/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
+++ b/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Autofac</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <Description>Optional Autofac integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
+++ b/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Idevs.Net.CoreLib.Generators.Abstractions</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <PackageTags>Idevs; CoreLib; Roslyn; SourceGenerator; Helpers</PackageTags>
     <Description>Reusable Roslyn helpers for source generators that integrate with Idevs.Net.CoreLib's DI conventions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
+++ b/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Serilog</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <Description>Optional Serilog integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary
- Add three GitHub Actions workflows: PR build/test + Copilot review request, auto-tag on merge to `main` from csproj `<Version>`, and NuGet publish on `v*` tag.
- Bump `<Version>` from `0.7.0` to `0.7.1` across all four packable projects (`Idevs.Net.CoreLib`, `.Autofac`, `.Serilog`, `.Generators.Abstractions`).
- Update `CHANGELOG.md` with `0.7.1` entry.

## Workflows
- `.github/workflows/ci.yml` — runs on PR to `main`. Restores, builds, and tests on .NET 8 + .NET 10 with NuGet caching. On `opened` / `reopened` / `ready_for_review`, requests `copilot-pull-request-reviewer` via the GitHub API (logs a warning if Copilot review isn't enabled — does not fail the PR).
- `.github/workflows/tag-on-merge.yml` — runs on push to `main`. Reads `<Version>` from `src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj` and creates `v{version}` annotated tag if it does not already exist (idempotent).
- `.github/workflows/publish-nuget.yml` — runs on `v*` tag push. Restores, builds Release, packs all four projects, uploads `.nupkg` artifacts, and pushes to nuget.org with `--skip-duplicate`. Uses the `nuget` deployment environment for approval/branch protection.

## Required setup (already configured)
- Repo environment `nuget` with `NUGET_API_KEY` secret.
- Workflow permissions set to "Read and write" so the tag job can push tags.
- GitHub Copilot code review enabled on the repo.

## Test plan
- [x] CI runs on this PR — build + test pass on .NET 8 and .NET 10
- [x] Copilot review is requested automatically
- [x] After merge, `tag-on-merge.yml` creates `v0.7.1` tag
- [ ] `publish-nuget.yml` triggers from the new tag and publishes 4 packages to nuget.org
- [ ] Verify on nuget.org that `Idevs.Net.CoreLib` 0.7.1 (and the three companion packages) appear within ~10 minutes