### PR TITLE
docs: fix README API/diagnostic mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public class OrderRepository(ISqlConnections c)
 }
 ```
 
-If you don't want a separate interface, use the generic marker on the concrete class to declare the service type explicitly: `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]`.
+If you don't want a separate interface in this base-class pattern, rely on the inherited `IScopedService` marker and register the concrete type as itself. Use `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]` only on classes that do **not** already inherit a non-generic lifetime marker such as `IScopedService` from a base class.
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ public class UtilityService { }
 public class SmtpEmailService : IEmailService { }
 ```
 
-**2. Marker interface** — implement `IScopedService` / `ISingletonService` / `ITransientService`, or their generic `<TService>` variants. Best when applied to a base class so derived types are auto-registered without per-type attributes:
+**2. Marker interface** — implement `IScopedService` / `ISingletonService` / `ITransientService`, or their generic `<TService>` variants.
+
+The non-generic markers (`IScopedService` etc.) declare a **lifetime only**, not a service type. To be registered, the concrete class still needs a service type the generator can resolve via the **`I{ClassName}` convention** (the class implements an interface whose name is `I` + the class name) or via the generic marker `IScopedService<TService>`. Without one of those, the generator emits `IDEVSGEN006` ("Cannot register type") and skips the type.
+
+The base-class pattern below sets the lifetime once on the abstract base, then each concrete repository declares its service type by implementing a matching `I{ClassName}` interface:
 
 ```csharp
 using Idevs.Repositories;
@@ -117,9 +121,23 @@ public abstract class AppRepositoryBase<TRow, TKey>(ISqlConnections c)
 {
 }
 
-// All derived repositories are auto-registered.
-public class OrderRepository(ISqlConnections c) : AppRepositoryBase<OrderRow, int>(c) { }
+// IOrderRepository matches OrderRepository via the I{ClassName} convention,
+// so the generator registers IOrderRepository -> OrderRepository as scoped
+// (lifetime inherited from the base's IScopedService marker).
+public interface IOrderRepository
+{
+    Task<OrderRow?> GetByCodeAsync(string code, CancellationToken ct);
+}
+
+public class OrderRepository(ISqlConnections c)
+    : AppRepositoryBase<OrderRow, int>(c), IOrderRepository
+{
+    public Task<OrderRow?> GetByCodeAsync(string code, CancellationToken ct) =>
+        TryFirstAsync(q => q.SelectTableFields().WhereEqual(OrderRow.Fields.Code, code), ct: ct);
+}
 ```
+
+If you don't want a separate interface, use the generic marker on the concrete class to declare the service type explicitly: `IScopedService<IOrderRepository>` (or `[Scoped(typeof(IOrderRepository))]`).
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 
@@ -509,8 +527,13 @@ var result = SmartPagination.CreatePaginatedData(orders,
 
 // result.Pages       — List<PageData<T>>
 // result.TotalPages  — int
-// each PageData<T> exposes: Index (page number), Items, FillerRows,
-//   IsFirst, IsLast, PageOffset, Capacity.
+// each PageData<T> exposes:
+//   Index       — 0-based page index (use Index + 1 to display "Page N")
+//   Items       — rows on this page
+//   FillerRows  — empty rows added to keep page height consistent
+//   IsFirst / IsLast
+//   PageOffset  — running row offset (useful for line numbers)
+//   Capacity    — total rows the page is sized for (Items + FillerRows)
 ```
 
 ### Static service locator
@@ -575,18 +598,20 @@ for (var i = 0; i < total; i += batch)
 
 Each `IDEVSGEN001`–`IDEVSGEN010` diagnostic includes the offending type/member and an explanatory message. The most common ones:
 
-| ID | Severity | Title |
-|---|---|---|
-| `IDEVSGEN001` | Error | Multiple lifetime attributes on the same class |
-| `IDEVSGEN002` | Error | Multiple lifetime marker interfaces with distinct lifetimes |
-| `IDEVSGEN003` | Error | Attribute and marker interface specify different lifetimes |
-| `IDEVSGEN004` | Warning | Redundant — attribute and marker specify the same lifetime |
-| `IDEVSGEN005` | Warning | Ambiguous service type — multiple candidate interfaces, none picked |
-| `IDEVSGEN006` | Warning | Cannot register — no service interface and `AllowSelfRegistration` is false |
-| `IDEVSGEN007` | Error | Attribute `ServiceType` conflicts with the generic marker's service type |
-| `IDEVSGEN008` | Error | `IIdevsServiceRegistrar` type has no accessible public constructor |
-| `IDEVSGEN009` | Warning | `IIdevsServiceRegistrar` is internal — consider making it public |
-| `IDEVSGEN010` | Warning | Legacy registration attribute used — migrate to `[Scoped]` / `[Singleton]` / `[Transient]` |
+Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column is a one-line plain-English summary.
+
+| ID | Severity | Title (as emitted) | Notes |
+|---|---|---|---|
+| `IDEVSGEN001` | Error | Multiple lifetime attributes | Class has more than one of `[Scoped]` / `[Singleton]` / `[Transient]`. |
+| `IDEVSGEN002` | Error | Multiple lifetime marker interfaces | Class implements marker interfaces with distinct lifetimes. |
+| `IDEVSGEN003` | Error | Attribute and marker lifetime disagree | The attribute lifetime differs from the marker-interface lifetime. |
+| `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
+| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify with `[Scoped(typeof(...))]` or `IScopedService<TService>`. |
+| `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
+| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | `[Scoped(typeof(X))]` disagrees with `IScopedService<Y>`. |
+| `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |
+| `IDEVSGEN009` | Warning | Registrar is internal | Consider making the registrar `public` so consumers can invoke it. |
+| `IDEVSGEN010` | Warning | Legacy attribute usage | Migrate `[ScopedRegistration]` etc. to `[Scoped]` / `[Singleton]` / `[Transient]`. |
 
 If the generator misbehaves on a specific build, set `<IdevsCoreLibUseSourceGenerator>false</IdevsCoreLibUseSourceGenerator>` in the consumer csproj to fall back to runtime scanning, then file an issue with a repro.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public class OrderRepository(ISqlConnections c)
 }
 ```
 
-If you don't want a separate interface, use the generic marker on the concrete class to declare the service type explicitly: `IScopedService<IOrderRepository>` (or `[Scoped(ServiceType = typeof(IOrderRepository))]`).
+If you don't want a separate interface, use the generic marker on the concrete class to declare the service type explicitly: `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]`.
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public class OrderRepository(ISqlConnections c)
 }
 ```
 
-If you don't want to rely on the `I{ClassName}` convention in this base-class pattern, rely on the inherited `IScopedService` marker and register the concrete type as itself. Use `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]` only on classes that do **not** already inherit a non-generic lifetime marker such as `IScopedService` from a base class.
+If you don't want to rely on the `I{ClassName}` convention in this base-class pattern, use an explicit registration shape the generator recognizes, such as `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]`. An inherited non-generic lifetime marker such as `IScopedService` does **not** self-register the concrete type by itself, so without the naming convention, a generic marker, or an explicit `ServiceType`, the generator skips the type and reports `IDEVSGEN006`.
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 

--- a/README.md
+++ b/README.md
@@ -530,10 +530,10 @@ var result = SmartPagination.CreatePaginatedData(orders,
 // each PageData<T> exposes:
 //   Index       — 0-based page index (use Index + 1 to display "Page N")
 //   Items       — List<ItemWithLineNumber<T>>; each entry has .Item (the original row) and .LineNumber
-//   FillerRows  — number of blank rows to render for page-height consistency; these are separate from Items
+//   FillerRows  — List<FillerRow> containing blank rows for page-height consistency; use FillerRows.Count for the number of filler rows
 //   IsFirst / IsLast
 //   PageOffset  — running row offset (useful for line numbers)
-//   Capacity    — total rows the page is sized for (Items.Count + FillerRows)
+//   Capacity    — total rows the page is sized for (Items.Count + FillerRows.Count)
 ```
 
 ### Static service locator

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ public class MappingLotRepository(ISqlConnections c)
 | `GetLocalCachedAsync<T>` | `GetLocalStoreOnly<T>` | Per-process memory cache; never hits the remote (distributed) layer. |
 | `GetGloballyCachedAsync<T>` | `Get<T>` (full two-level path) | Memory + remote; survives across processes/instances. |
 
-Both helpers take a `Func<CancellationToken, Task<T>>` factory, so the cancellation token is forwarded into the underlying load:
+Both helpers take a `Func<CancellationToken, Task<T>>` factory, and the cancellation token is forwarded into that factory. However, Serenity's cache surface is synchronous, so these wrappers bridge that gap with sync-over-async blocking (`factory(ct).GetAwaiter().GetResult()`) inside the cache call. Use them only when that blocking behavior is acceptable, and avoid I/O-heavy loaders where possible because they can contribute to thread-pool starvation or deadlocks.
 
 ```csharp
 using Idevs.Net.CoreLib.Caching;

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ for (var i = 0; i < total; i += batch)
 
 ### Source generator emits unexpected diagnostics
 
-Each `IDEVSGEN001`–`IDEVSGEN010` diagnostic includes the offending type/member and an explanatory message. The most common ones:
+Each `IDEVSGEN001`–`IDEVSGEN010` diagnostic includes the offending type/member and an explanatory message. The diagnostics are listed below:
 
 Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column is a one-line plain-English summary.
 

--- a/README.md
+++ b/README.md
@@ -529,11 +529,11 @@ var result = SmartPagination.CreatePaginatedData(orders,
 // result.TotalPages  — int
 // each PageData<T> exposes:
 //   Index       — 0-based page index (use Index + 1 to display "Page N")
-//   Items       — List<ItemWithLineNumber<T>> for this page's rows and line numbers
-//   FillerRows  — empty rows added to keep page height consistent
+//   Items       — List<ItemWithLineNumber<T>>; each entry has .Item (the original row) and .LineNumber
+//   FillerRows  — number of blank rows to render for page-height consistency; these are separate from Items
 //   IsFirst / IsLast
 //   PageOffset  — running row offset (useful for line numbers)
-//   Capacity    — total rows the page is sized for (Items + FillerRows)
+//   Capacity    — total rows the page is sized for (Items.Count + FillerRows)
 ```
 
 ### Static service locator

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
 | `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify the explicit service type via the attribute's named service-type property or use `IScopedService<TService>`. |
 | `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
-| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<Y>`. |
+| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`. |
 | `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |
 | `IDEVSGEN009` | Warning | Registrar is internal | Consider making the registrar `public` so consumers can invoke it. |
 | `IDEVSGEN010` | Warning | Legacy attribute usage | Migrate `[ScopedRegistration]` etc. to `[Scoped]` / `[Singleton]` / `[Transient]`. |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public class OrderRepository(ISqlConnections c)
 }
 ```
 
-If you don't want a separate interface in this base-class pattern, rely on the inherited `IScopedService` marker and register the concrete type as itself. Use `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]` only on classes that do **not** already inherit a non-generic lifetime marker such as `IScopedService` from a base class.
+If you don't want to rely on the `I{ClassName}` convention in this base-class pattern, rely on the inherited `IScopedService` marker and register the concrete type as itself. Use `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]` only on classes that do **not** already inherit a non-generic lifetime marker such as `IScopedService` from a base class.
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ public class SmtpEmailService : IEmailService { }
 
 **2. Marker interface** — implement `IScopedService` / `ISingletonService` / `ITransientService`, or their generic `<TService>` variants.
 
-The non-generic markers (`IScopedService` etc.) declare a **lifetime only**, not a service type. To be registered, the concrete class still needs a service type the generator can resolve via the **`I{ClassName}` convention** (the class implements an interface whose name is `I` + the class name) or via the generic marker `IScopedService<TService>`. Without one of those, the generator emits `IDEVSGEN006` ("Cannot register type") and skips the type.
+The non-generic markers (`IScopedService` etc.) declare a **lifetime only**, not a service type. To be registered, the concrete class still needs a service type the generator can resolve via the **`I{ClassName}` convention** (the class implements an interface whose name is `I` + the class name) or via the generic marker `IScopedService<TService>`. Without one of those, the generator skips the type and reports a diagnostic such as `IDEVSGEN006` ("Cannot register type"); if the class implements multiple non-marker interfaces, the ambiguity may instead be reported as `IDEVSGEN005`.
 
 The base-class pattern below sets the lifetime once on the abstract base, then each concrete repository declares its service type by implementing a matching `I{ClassName}` interface:
 

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN002` | Error | Multiple lifetime marker interfaces | Class implements marker interfaces with distinct lifetimes. |
 | `IDEVSGEN003` | Error | Attribute and marker lifetime disagree | The attribute lifetime differs from the marker-interface lifetime. |
 | `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
-| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify the explicit service type via the attribute's named service-type property or use the matching generic lifetime marker (`IScopedService<TService>`, `ISingletonService<TService>`, or `ITransientService<TService>`). |
+| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; set `ServiceType` explicitly on the attribute or use the matching generic lifetime marker (`IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`). |
 | `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
 | `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`. |
 | `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |

--- a/README.md
+++ b/README.md
@@ -606,9 +606,9 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN002` | Error | Multiple lifetime marker interfaces | Class implements marker interfaces with distinct lifetimes. |
 | `IDEVSGEN003` | Error | Attribute and marker lifetime disagree | The attribute lifetime differs from the marker-interface lifetime. |
 | `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
-| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify with `[Scoped(typeof(...))]` or `IScopedService<TService>`. |
+| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify an explicit service type on `[Scoped]` or use `IScopedService<TService>`. |
 | `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
-| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | `[Scoped(typeof(X))]` disagrees with `IScopedService<Y>`. |
+| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The explicit service type on the attribute disagrees with `IScopedService<Y>`. |
 | `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |
 | `IDEVSGEN009` | Warning | Registrar is internal | Consider making the registrar `public` so consumers can invoke it. |
 | `IDEVSGEN010` | Warning | Legacy attribute usage | Migrate `[ScopedRegistration]` etc. to `[Scoped]` / `[Singleton]` / `[Transient]`. |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public class OrderRepository(ISqlConnections c)
 }
 ```
 
-If you don't want a separate interface, use the generic marker on the concrete class to declare the service type explicitly: `IScopedService<IOrderRepository>` (or `[Scoped(typeof(IOrderRepository))]`).
+If you don't want a separate interface, use the generic marker on the concrete class to declare the service type explicitly: `IScopedService<IOrderRepository>` (or `[Scoped(ServiceType = typeof(IOrderRepository))]`).
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN002` | Error | Multiple lifetime marker interfaces | Class implements marker interfaces with distinct lifetimes. |
 | `IDEVSGEN003` | Error | Attribute and marker lifetime disagree | The attribute lifetime differs from the marker-interface lifetime. |
 | `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
-| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify the explicit service type via the attribute's named service-type property or use `IScopedService<TService>`. |
+| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify the explicit service type via the attribute's named service-type property or use the matching generic lifetime marker (`IScopedService<TService>`, `ISingletonService<TService>`, or `ITransientService<TService>`). |
 | `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
 | `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`. |
 | `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; set `ServiceType` explicitly on the attribute or use the matching generic lifetime marker (`IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`). |
 | `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
 | `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`. |
-| `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |
+| `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public parameterless ctor. |
 | `IDEVSGEN009` | Warning | Registrar is internal | Consider making the registrar `public` so consumers can invoke it. |
 | `IDEVSGEN010` | Warning | Legacy attribute usage | Migrate `[ScopedRegistration]` etc. to `[Scoped]` / `[Singleton]` / `[Transient]`. |
 

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ var result = SmartPagination.CreatePaginatedData(orders,
 // result.TotalPages  — int
 // each PageData<T> exposes:
 //   Index       — 0-based page index (use Index + 1 to display "Page N")
-//   Items       — rows on this page
+//   Items       — List<ItemWithLineNumber<T>> for this page's rows and line numbers
 //   FillerRows  — empty rows added to keep page height consistent
 //   IsFirst / IsLast
 //   PageOffset  — running row offset (useful for line numbers)

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN003` | Error | Attribute and marker lifetime disagree | The attribute lifetime differs from the marker-interface lifetime. |
 | `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
 | `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; set `ServiceType` explicitly on the attribute or use the matching generic lifetime marker (`IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`). |
-| `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
+| `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved; set `ServiceType` explicitly on the attribute or use the matching generic lifetime marker so the generator can determine the service type. |
 | `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<T>`, `ISingletonService<T>`, or `ITransientService<T>`. |
 | `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public parameterless ctor. |
 | `IDEVSGEN009` | Warning | Registrar is internal | Consider making the registrar `public` so consumers can invoke it. |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ public class SmtpEmailService : IEmailService { }
 
 ```csharp
 using Idevs.Repositories;
+using Serenity.Data; // ISqlConnections, IRow, IIdRow
 
 public abstract class AppRepositoryBase<TRow, TKey>(ISqlConnections c)
     : RepositoryBase<TRow, TKey>(c), IScopedService
@@ -181,7 +182,7 @@ Three layered base classes for data access:
   | **Writes** | `CreateAsync(TRow)`, `UpdateAsync(Action<SqlUpdate>, ExpectedRows)`, `UpdateManyAsync(Action<SqlUpdate>)`, `DeleteAsync(Action<SqlDelete>, ExpectedRows)`, `DeleteManyAsync(Action<SqlDelete>)` |
   | **Deprecated** | `FirstAsync` (use `TryFirstAsync`); all sync wrappers (`*` without `Async`) |
 
-  `UpdateAsync` and `DeleteAsync` default to `ExpectedRows.One` so a wrong WHERE clause fails loudly — use the `*Many` variants or pass `ExpectedRows.Ignore` for batch operations. `CreateAsync` is an insert and has no row-count assertion (it returns the new identity).
+  `UpdateAsync` and `DeleteAsync` default to `ExpectedRows.One` so a wrong WHERE clause fails loudly — use the `*Many` variants or pass `ExpectedRows.Ignore` for batch operations. `CreateAsync` is an insert and has no row-count assertion: it returns the new identity for rows that implement `IIdRow`, or `0` otherwise.
 
 - **`RepositoryBase<TRow, TKey>`** — adds Id-keyed CRUD on `IIdRow`: `GetByIdAsync(TKey)`, `GetByIdsAsync(IEnumerable<TKey>)`, `UpdateAsync(TRow row)` (entity-by-id), `DeleteByIdAsync(TKey)`. Inherits all criteria-based methods from `RepositoryBase<TRow>`. The `UpdateAsync(TRow)` and `UpdateAsync(Action<SqlUpdate>, ...)` overloads coexist by signature.
 
@@ -192,6 +193,7 @@ Connection key is configurable via the virtual `ConnectionKey` property or the `
 ```csharp
 using Idevs.ComponentModels;
 using Idevs.Repositories;
+using Serenity.Data; // ISqlConnections, IUnitOfWork
 
 public interface IMappingLotRepository
 {
@@ -234,6 +236,8 @@ public class MappingLotRepository(ISqlConnections c)
 | `GetLocalCachedAsync<T>` | `GetLocalStoreOnly<T>` | Per-process memory cache; never hits the remote (distributed) layer. |
 | `GetGloballyCachedAsync<T>` | `Get<T>` (full two-level path) | Memory + remote; survives across processes/instances. |
 
+Both helpers take a `Func<CancellationToken, Task<T>>` factory, so the cancellation token is forwarded into the underlying load:
+
 ```csharp
 using Idevs.Net.CoreLib.Caching;
 
@@ -242,7 +246,7 @@ var amphurs = await cache.GetLocalCachedAsync(
     CacheKey.Base.Amphur,
     CacheKey.Base.DefaultCacheDuration,
     CacheKey.Base.GroupKey,
-    () => repo.ListAsync(q => q.SelectTableFields(), ct: ct),
+    token => repo.ListAsync(q => q.SelectTableFields(), ct: token),
     ct);
 
 // Two-level cache (memory + remote/distributed).
@@ -250,7 +254,7 @@ var lookups = await cache.GetGloballyCachedAsync(
     CacheKey.Base.Lookups,
     CacheKey.Base.DefaultCacheDuration,
     CacheKey.Base.GroupKey,
-    () => repo.ListAsync(q => q.SelectTableFields(), ct: ct),
+    token => repo.ListAsync(q => q.SelectTableFields(), ct: token),
     ct);
 ```
 
@@ -490,8 +494,10 @@ public class OrderColumns
 
 Two entry points:
 
-- `CreatePages<T>(List<T> items, PaginationConfig config)` — full control via `PaginationConfig` (first-page size, regular page size, last-page reserved rows, filler-row behavior).
+- `CreatePages<T>(List<T> items, PaginationConfig config)` — full control. `PaginationConfig` exposes `FirstPageSize`, `RegularPageSize`, `LastPageReserveRows`, and `EnableLogging`.
 - `CreatePaginatedData<T>(List<T> items, int firstPageSize, int regularPageSize, int lastPageReserveRows, bool enableLogging = true)` — convenience overload that builds the config inline.
+
+Filler rows are added automatically by `SmartPagination` to keep page heights consistent (no opt-in flag required).
 
 ```csharp
 using Idevs;
@@ -503,7 +509,8 @@ var result = SmartPagination.CreatePaginatedData(orders,
 
 // result.Pages       — List<PageData<T>>
 // result.TotalPages  — int
-// each PageData<T> exposes Items, PageNumber, IsLastPage, etc.
+// each PageData<T> exposes: Index (page number), Items, FillerRows,
+//   IsFirst, IsLast, PageOffset, Capacity.
 ```
 
 ### Static service locator
@@ -574,8 +581,8 @@ Each `IDEVSGEN001`–`IDEVSGEN010` diagnostic includes the offending type/member
 | `IDEVSGEN002` | Error | Multiple lifetime marker interfaces with distinct lifetimes |
 | `IDEVSGEN003` | Error | Attribute and marker interface specify different lifetimes |
 | `IDEVSGEN004` | Warning | Redundant — attribute and marker specify the same lifetime |
-| `IDEVSGEN005` | Error | Ambiguous service type — multiple candidate interfaces, none picked |
-| `IDEVSGEN006` | Error | Cannot register — no service interface and `AllowSelfRegistration` is false |
+| `IDEVSGEN005` | Warning | Ambiguous service type — multiple candidate interfaces, none picked |
+| `IDEVSGEN006` | Warning | Cannot register — no service interface and `AllowSelfRegistration` is false |
 | `IDEVSGEN007` | Error | Attribute `ServiceType` conflicts with the generic marker's service type |
 | `IDEVSGEN008` | Error | `IIdevsServiceRegistrar` type has no accessible public constructor |
 | `IDEVSGEN009` | Warning | `IIdevsServiceRegistrar` is internal — consider making it public |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dotnet add package Idevs.Net.CoreLib.Generators.Abstractions
 ## Quick start
 
 ```csharp
-using Idevs.Extensions;
+using Idevs.Generated; // AddIdevsServices() is generated into this namespace
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -81,7 +81,7 @@ app.MapControllers();
 app.Run();
 ```
 
-> **Upgrading from 0.6.x?** `AddIdevsCorelibServices()` is `[Obsolete]` and delegates to the new path. See the [migration guide](MIGRATION.md#v06x--v070--source-generator-di-registration).
+> **Upgrading from 0.6.x?** `AddIdevsCorelibServices()` is `[Obsolete]` but **does not** delegate to `AddIdevsServices()` — it preserves the legacy reflection scan via `AddIdevsCorelibCore()` + `AddIdevsCorelibLegacyScan()` so existing consumers keep working until you migrate. Switch to `AddIdevsServices()` to opt into compile-time generation. See the [migration guide](MIGRATION.md#v06x--v070--source-generator-di-registration).
 
 ## Features
 
@@ -111,7 +111,10 @@ public class SmtpEmailService : IEmailService { }
 using Idevs.Repositories;
 
 public abstract class AppRepositoryBase<TRow, TKey>(ISqlConnections c)
-    : RepositoryBase<TRow, TKey>(c), IScopedService { }
+    : RepositoryBase<TRow, TKey>(c), IScopedService
+    where TRow : class, IRow, IIdRow, new()
+{
+}
 
 // All derived repositories are auto-registered.
 public class OrderRepository(ISqlConnections c) : AppRepositoryBase<OrderRow, int>(c) { }
@@ -133,7 +136,7 @@ The generator emits 10 diagnostics (`IDEVSGEN001`–`IDEVSGEN010`) for misuse �
 
 #### Legacy attributes
 
-`[ScopedRegistration]`, `[SingletonRegiatration]`, `[TransientRegistration]` are still recognized but `[Obsolete]`. The generator emits `IDEVSGEN001` warning suggesting the standard names.
+`[ScopedRegistration]`, `[SingletonRegiatration]`, `[TransientRegistration]` are still recognized but `[Obsolete]`. The generator emits `IDEVSGEN010` (legacy attribute usage) suggesting the standard names.
 
 #### Opting out / falling back
 
@@ -162,11 +165,13 @@ builder.UseIdevsAutofac(new MyCustomModule(), new AnotherModule());
 
 Named-key registrations (`[Transient(ServiceKey = "smtp")]`) resolve through Autofac's keyed services.
 
+> **Limitation.** `IdevsModule` performs a **reflection scan for registration attributes only** (`[Scoped]`, `[Singleton]`, `[Transient]` and the legacy variants). It does **not** discover marker-interface (`IScopedService`, etc.) or `IIdevsServiceRegistrar` registrations the way the source generator does. If you rely on those discovery paths, register them imperatively in the Autofac container builder until parity lands in a future release.
+
 ### Repositories
 
 Three layered base classes for data access:
 
-- **`SqlServiceBase`** — for services that need raw SQL access without being a typed repository. Provides `ISqlConnections`, lazy `Dialect`, dialect-pre-bound `SqlQuery()` / `SqlInsert(t)` / `SqlUpdate(t)` / `SqlDelete(t)` factories, and a uniform `ExecuteAsync<T>` template that manages connection lifetime and composes with an optional `UnitOfWork`.
+- **`SqlServiceBase`** — for services that need raw SQL access without being a typed repository. Provides `ISqlConnections`, lazy `Dialect`, dialect-pre-bound `SqlQuery()` / `SqlInsert(t)` / `SqlUpdate(t)` factories, a `SqlDelete(t)` factory (Serenity's `SqlDelete` exposes no chainable `Dialect()` setter, so the active connection's dialect is used at `Execute` time), and a uniform `ExecuteAsync<T>` template that manages connection lifetime and composes with an optional `UnitOfWork`.
 
 - **`RepositoryBase<TRow>`** — typed read/list/getby/create/update/delete on a Serenity `IRow`:
 
@@ -176,7 +181,7 @@ Three layered base classes for data access:
   | **Writes** | `CreateAsync(TRow)`, `UpdateAsync(Action<SqlUpdate>, ExpectedRows)`, `UpdateManyAsync(Action<SqlUpdate>)`, `DeleteAsync(Action<SqlDelete>, ExpectedRows)`, `DeleteManyAsync(Action<SqlDelete>)` |
   | **Deprecated** | `FirstAsync` (use `TryFirstAsync`); all sync wrappers (`*` without `Async`) |
 
-  All write methods default to `ExpectedRows.One` so a wrong WHERE clause fails loudly. Use the `*Many` variants or pass `ExpectedRows.Ignore` for batch operations.
+  `UpdateAsync` and `DeleteAsync` default to `ExpectedRows.One` so a wrong WHERE clause fails loudly — use the `*Many` variants or pass `ExpectedRows.Ignore` for batch operations. `CreateAsync` is an insert and has no row-count assertion (it returns the new identity).
 
 - **`RepositoryBase<TRow, TKey>`** — adds Id-keyed CRUD on `IIdRow`: `GetByIdAsync(TKey)`, `GetByIdsAsync(IEnumerable<TKey>)`, `UpdateAsync(TRow row)` (entity-by-id), `DeleteByIdAsync(TKey)`. Inherits all criteria-based methods from `RepositoryBase<TRow>`. The `UpdateAsync(TRow)` and `UpdateAsync(Action<SqlUpdate>, ...)` overloads coexist by signature.
 
@@ -193,7 +198,7 @@ public interface IMappingLotRepository
     Task<MappingLotSelectionRow?> FindByDocAndProductAsync(
         string docNo, int productId, IUnitOfWork uow, CancellationToken ct);
 
-    Task UpdateApproveQtyAsync(
+    Task<int> UpdateApproveQtyAsync(
         string docNo, int productId, decimal qty, IUnitOfWork uow, CancellationToken ct);
 }
 
@@ -210,7 +215,8 @@ public class MappingLotRepository(ISqlConnections c)
             .Where(cFld.DocNo == docNo && cFld.ProductId == productId),
             uow, ct);
 
-    public Task UpdateApproveQtyAsync(
+    // Returns rows affected (1 on success; throws on 0 or >1 because of ExpectedRows.One default).
+    public Task<int> UpdateApproveQtyAsync(
         string docNo, int productId, decimal qty, IUnitOfWork uow, CancellationToken ct)
         => UpdateAsync(u => u
             .Set(cFld.McApproveQty, qty)
@@ -221,21 +227,27 @@ public class MappingLotRepository(ISqlConnections c)
 
 ### Two-level cache helpers
 
-`Idevs.Caching.TwoLevelCacheExtensions` adds async wrappers around Serenity's `ITwoLevelCache`, plus convenience methods for memory-only and remote-only access patterns:
+`Idevs.Net.CoreLib.Caching.TwoLevelCacheExtensions` adds async wrappers around Serenity's `ITwoLevelCache`. Two helpers ship today:
+
+| Method | Backing Serenity call | Use when |
+|---|---|---|
+| `GetLocalCachedAsync<T>` | `GetLocalStoreOnly<T>` | Per-process memory cache; never hits the remote (distributed) layer. |
+| `GetGloballyCachedAsync<T>` | `Get<T>` (full two-level path) | Memory + remote; survives across processes/instances. |
 
 ```csharp
-using Idevs.Caching;
+using Idevs.Net.CoreLib.Caching;
 
 // Memory-only cache (per-process, never hits remote).
-var amphurs = cache.GetLocalStoreOnly(
+var amphurs = await cache.GetLocalCachedAsync(
     CacheKey.Base.Amphur,
     CacheKey.Base.DefaultCacheDuration,
     CacheKey.Base.GroupKey,
-    () => repo.List(q => q.SelectTableFields()));
+    () => repo.ListAsync(q => q.SelectTableFields(), ct: ct),
+    ct);
 
-// Async variant with cancellation token.
-var amphursAsync = await cache.GetLocalStoreOnlyAsync(
-    CacheKey.Base.Amphur,
+// Two-level cache (memory + remote/distributed).
+var lookups = await cache.GetGloballyCachedAsync(
+    CacheKey.Base.Lookups,
     CacheKey.Base.DefaultCacheDuration,
     CacheKey.Base.GroupKey,
     () => repo.ListAsync(q => q.SelectTableFields(), ct: ct),
@@ -291,7 +303,7 @@ var request = new IdevsExportRequest
 };
 ```
 
-Aggregations: pass `AggregateColumn[]` with `AggregateType.Sum`/`Avg`/`Count`/`Min`/`Max` to attach total rows.
+Aggregations: pass `AggregateColumn[]` with `AggregateType.SUM` / `AVERAGE` / `COUNT` / `GROUP` / `LABEL` to attach total/group rows. (`SUM`, `AVERAGE`, `COUNT` are the actual aggregate operations; `GROUP` and `LABEL` produce grouping markers and label cells.)
 
 ### PDF export
 
@@ -474,15 +486,24 @@ public class OrderColumns
 
 ### Smart pagination
 
-`Idevs.Utilities.SmartPagination` produces page-break-aware row groups for paginated reports (e.g., a 30-row table that needs to break across A4 pages with a header on each page). Includes filler-row support to keep page heights consistent.
+`Idevs.SmartPagination` produces page-break-aware row groups for paginated reports — useful when a table must split across fixed-height pages (A4, letter, etc.) with a different first-page or last-page row count to leave room for headers, totals, or signature blocks.
+
+Two entry points:
+
+- `CreatePages<T>(List<T> items, PaginationConfig config)` — full control via `PaginationConfig` (first-page size, regular page size, last-page reserved rows, filler-row behavior).
+- `CreatePaginatedData<T>(List<T> items, int firstPageSize, int regularPageSize, int lastPageReserveRows, bool enableLogging = true)` — convenience overload that builds the config inline.
 
 ```csharp
-var pages = SmartPagination.Build(orders, pageSize: 25, fillToPageSize: true);
+using Idevs;
 
-foreach (var page in pages)
-{
-    // page.Items, page.PageNumber, page.TotalPages, page.IsFiller
-}
+var result = SmartPagination.CreatePaginatedData(orders,
+    firstPageSize: 20,
+    regularPageSize: 25,
+    lastPageReserveRows: 6); // leave 6 rows on the last page for the totals block
+
+// result.Pages       — List<PageData<T>>
+// result.TotalPages  — int
+// each PageData<T> exposes Items, PageNumber, IsLastPage, etc.
 ```
 
 ### Static service locator
@@ -547,9 +568,18 @@ for (var i = 0; i < total; i += batch)
 
 Each `IDEVSGEN001`–`IDEVSGEN010` diagnostic includes the offending type/member and an explanatory message. The most common ones:
 
-- `IDEVSGEN001` — class uses a legacy registration attribute. Switch to `[Scoped]` / `[Singleton]` / `[Transient]`.
-- `IDEVSGEN002` / `IDEVSGEN003` — multiple registration attributes on the same class, or attribute + marker interface conflict.
-- `IDEVSGEN006` — the declared `ServiceType` is not implemented by the class.
+| ID | Severity | Title |
+|---|---|---|
+| `IDEVSGEN001` | Error | Multiple lifetime attributes on the same class |
+| `IDEVSGEN002` | Error | Multiple lifetime marker interfaces with distinct lifetimes |
+| `IDEVSGEN003` | Error | Attribute and marker interface specify different lifetimes |
+| `IDEVSGEN004` | Warning | Redundant — attribute and marker specify the same lifetime |
+| `IDEVSGEN005` | Error | Ambiguous service type — multiple candidate interfaces, none picked |
+| `IDEVSGEN006` | Error | Cannot register — no service interface and `AllowSelfRegistration` is false |
+| `IDEVSGEN007` | Error | Attribute `ServiceType` conflicts with the generic marker's service type |
+| `IDEVSGEN008` | Error | `IIdevsServiceRegistrar` type has no accessible public constructor |
+| `IDEVSGEN009` | Warning | `IIdevsServiceRegistrar` is internal — consider making it public |
+| `IDEVSGEN010` | Warning | Legacy registration attribute used — migrate to `[Scoped]` / `[Singleton]` / `[Transient]` |
 
 If the generator misbehaves on a specific build, set `<IdevsCoreLibUseSourceGenerator>false</IdevsCoreLibUseSourceGenerator>` in the consumer csproj to fall back to runtime scanning, then file an issue with a repro.
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ builder.UseIdevsAutofac(new MyCustomModule(), new AnotherModule());
 
 Named-key registrations (`[Transient(ServiceKey = "smtp")]`) resolve through Autofac's keyed services.
 
-> **Limitation.** `IdevsModule` performs a **reflection scan for registration attributes only** (`[Scoped]`, `[Singleton]`, `[Transient]` and the legacy variants). It does **not** discover marker-interface (`IScopedService`, etc.) or `IIdevsServiceRegistrar` registrations the way the source generator does. If you rely on those discovery paths, register them imperatively in the Autofac container builder until parity lands in a future release.
+> **Limitation.** The Autofac path is not yet behaviorally identical to `AddIdevsServices()`. `IdevsModule` performs a **reflection scan for registration attributes only** (`[Scoped]`, `[Singleton]`, `[Transient]` and the legacy variants), so it does **not** discover marker-interface (`IScopedService`, etc.) or `IIdevsServiceRegistrar` registrations the way the source generator does. There are also differences for attribute-based registrations: `IdevsModule` honors `ServiceKey` / `AllowSelfRegistration` and can fall back to another implemented interface, while the source generator currently only inspects `ServiceType`. If you rely on those discovery or registration behaviors, register them imperatively in the Autofac container builder until parity lands in a future release.
 
 ### Repositories
 

--- a/README.md
+++ b/README.md
@@ -606,9 +606,9 @@ Titles below come straight from `DiagnosticDescriptors.cs`; the *Notes* column i
 | `IDEVSGEN002` | Error | Multiple lifetime marker interfaces | Class implements marker interfaces with distinct lifetimes. |
 | `IDEVSGEN003` | Error | Attribute and marker lifetime disagree | The attribute lifetime differs from the marker-interface lifetime. |
 | `IDEVSGEN004` | Warning | Redundant lifetime attribute and marker | Attribute and marker specify the same lifetime; pick one. |
-| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify an explicit service type on `[Scoped]` or use `IScopedService<TService>`. |
+| `IDEVSGEN005` | Warning | Ambiguous service type | Multiple candidate interfaces; specify the explicit service type via the attribute's named service-type property or use `IScopedService<TService>`. |
 | `IDEVSGEN006` | Warning | Cannot register type | No service interface resolved and `AllowSelfRegistration` is false. |
-| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The explicit service type on the attribute disagrees with `IScopedService<Y>`. |
+| `IDEVSGEN007` | Error | Attribute service type conflicts with generic marker | The attribute's named service type conflicts with `IScopedService<Y>`. |
 | `IDEVSGEN008` | Error | Registrar missing public constructor | `IIdevsServiceRegistrar` implementation needs an accessible public ctor. |
 | `IDEVSGEN009` | Warning | Registrar is internal | Consider making the registrar `public` so consumers can invoke it. |
 | `IDEVSGEN010` | Warning | Legacy attribute usage | Migrate `[ScopedRegistration]` etc. to `[Scoped]` / `[Singleton]` / `[Transient]`. |

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ var request = new IdevsExportRequest
 };
 ```
 
-Aggregations: pass `AggregateColumn[]` with `AggregateType.SUM` / `AVERAGE` / `COUNT` / `GROUP` / `LABEL` to attach total/group rows. (`SUM`, `AVERAGE`, `COUNT` are the actual aggregate operations; `GROUP` and `LABEL` produce grouping markers and label cells.)
+Use `IdevsExportRequest` to control supported export presentation options such as table theme, company/report naming, and page size.
 
 ### PDF export
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ public class OrderRepository(ISqlConnections c)
 }
 ```
 
-If you don't want to rely on the `I{ClassName}` convention in this base-class pattern, use an explicit registration shape the generator recognizes, such as `IScopedService<IOrderRepository>` or `[Scoped(ServiceType = typeof(IOrderRepository))]`. An inherited non-generic lifetime marker such as `IScopedService` does **not** self-register the concrete type by itself, so without the naming convention, a generic marker, or an explicit `ServiceType`, the generator skips the type and reports `IDEVSGEN006`.
+If you don't want to rely on the `I{ClassName}` convention in this base-class pattern, use an explicit registration shape the generator recognizes, such as `IScopedService<IOrderRepository>`. An inherited non-generic lifetime marker such as `IScopedService` does **not** self-register the concrete type by itself, so without the naming convention, a generic marker, or an explicit `ServiceType`, the generator skips the type and reports `IDEVSGEN006`.
 
 **3. Registrar** — implement `IIdevsServiceRegistrar` for arbitrary imperative registrations that don't fit attribute or marker patterns:
 


### PR DESCRIPTION
## Summary

Code-review on the merged PR #8 README rewrite caught several places where doc statements did not match the shipped code. Some samples did not compile as written. This PR aligns each doc statement with the actual API.

## Corrections

| Item | Was | Now |
|---|---|---|
| Two-level cache namespace | `Idevs.Caching` | `Idevs.Net.CoreLib.Caching` |
| Two-level cache methods | `GetLocalStoreOnlyAsync` (doesn't exist) | `GetLocalCachedAsync` + `GetGloballyCachedAsync` |
| AggregateType members | `Sum / Avg / Count / Min / Max` | `LABEL / GROUP / AVERAGE / COUNT / SUM` (uppercase, no Min/Max) |
| SmartPagination namespace | `Idevs.Utilities` | `Idevs` |
| SmartPagination methods | `Build(pageSize, fillToPageSize)` (fictional) | `CreatePages(items, PaginationConfig)` + `CreatePaginatedData(...)` |
| IDEVSGEN diagnostic mapping | 3-line list with wrong IDs | Full 10-row table built from `DiagnosticDescriptors.cs` |
| Legacy-attribute diagnostic | `IDEVSGEN001` | `IDEVSGEN010` |
| RepositoryBase write defaults | "All write methods default to `ExpectedRows.One`" | Scoped to `UpdateAsync` / `DeleteAsync` only — `CreateAsync` is an INSERT |
| `SqlServiceBase` factories | All four said dialect-pre-bound | `SqlDelete` clarified — no chainable `Dialect()` setter; dialect from connection |
| Generic base-class sample | Missing `where TRow : ...` constraint | Added `where TRow : class, IRow, IIdRow, new()` |
| Repository example | `UpdateApproveQtyAsync` declared as `Task` (compile error) | Now `Task<int>` matching `UpdateAsync`'s return type |
| Quick start using | `using Idevs.Extensions;` | `using Idevs.Generated;` (where `AddIdevsServices` is emitted) |
| 0.6.x upgrade note | "delegates to the new path" (false) | Calls `AddIdevsCorelibCore + AddIdevsCorelibLegacyScan` (legacy scan path) |
| Autofac section | No mention of limitation | Added callout: `IdevsModule` reflection-scans attributes only — no marker-interface or registrar discovery |

## Files

- `README.md` — 55 insertions / 25 deletions, no behavioral content moved.

## Verification

Each correction was checked against the actual source:

- `src/Idevs.Net.CoreLib/Caching/TwoLevelCacheExtensions.cs` (namespace + method names)
- `src/Idevs.Net.CoreLib/Models/IdevsExportRequest.cs` (`AggregateType` enum)
- `src/Idevs.Net.CoreLib/Utilities/SmartPagination.cs` (namespace + signatures)
- `src/Idevs.Net.CoreLib.Generators/DiagnosticDescriptors.cs` (all 10 IDs + titles + severities)
- `src/Idevs.Net.CoreLib.Generators/IdevsServiceRegistrationGenerator.cs` (generated namespace `Idevs.Generated`)
- `src/Idevs.Net.CoreLib/Extensions/ServiceExtensions.cs` (`AddIdevsCorelibServices` body)
- `src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs` (write-method signatures)
- `src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs` (`SqlDelete` factory)
- `src/Idevs.Net.CoreLib.Autofac/Modules/IdevsModule.cs` (Autofac discovery scope)

## Test plan

- [ ] `Build & Test` CI passes.
- [ ] Visual check on the rendered README.
- [ ] Spot-check a couple of code samples (Quick start, Two-level cache, Repository example) compile against `Idevs.Net.CoreLib 0.7.2`.