### PR TITLE
feat: unit-of-work helpers — BeginUnitOfWork + CommitOnSuccessAsync (0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.7.3 (2026-05-03)
+
+### Added
+
+- `SqlServiceBase.BeginUnitOfWork(IUnitOfWork? uow = null)` returns a new
+  `UnitOfWorkScope` (`IDisposable` + `IAsyncDisposable`). When a caller-owned
+  `IUnitOfWork` is supplied, the scope wraps it without taking ownership
+  (Commit/Dispose are no-ops). Otherwise the scope opens a fresh connection
+  + `UnitOfWork`; the caller MUST call `Commit()` before the using block
+  exits, otherwise dispose rolls back. Designed for long methods with
+  sequential statements, conditional branches, and early returns.
+- `SqlServiceBase.CommitOnSuccessAsync<T>(work, uow?, ct?)` and the
+  non-generic `CommitOnSuccessAsync(work, uow?, ct?)` — lambda form that
+  opens a scope, runs the delegate, commits on normal return, and rolls
+  back on exception. Designed for short blocks where the whole transaction
+  body fits in one expression.
+- `SqlServiceBase.CommitOnSuccess<T>` / `CommitOnSuccess` sync
+  `[Obsolete]` wrappers following the existing migration pattern.
+- New public type `Idevs.Repositories.UnitOfWorkScope`.
+
+### Why
+
+Closes a real gap: a parent repository method that didn't accept an
+`IUnitOfWork` parameter could not coordinate atomic writes across child
+repositories — each call opened its own connection and ran in a separate
+transaction. The new helpers implement the canonical "use caller's UoW
+if provided, otherwise open one and commit/rollback" pattern. Pick the
+shape that matches the call site: lambda for short blocks, scope for
+long methods.
+
 ## 0.7.2 (2026-05-02)
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,12 +4,120 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 
 ## Contents
 
+- [v0.7.2 → v0.7.3 — Unit of Work Helpers (BeginUnitOfWork + CommitOnSuccessAsync)](#v072--v073--unit-of-work-helpers-beginunitofwork--commitonsuccessasync)
 - [v0.7.1 → v0.7.2 — RepositoryBase Criteria-Based Update/Delete + TryFirst Alias](#v071--v072--repositorybase-criteria-based-updatedelete--tryfirst-alias)
 - [v0.6.x → v0.7.0 — Source-Generator DI Registration](#v06x--v070--source-generator-di-registration)
 - [v0.5.0 → v0.6.0 — RepositoryBase Redesign](#v050--v060--repositorybase-redesign)
 - [v0.3.x → v0.5.0 — Package Layout & DI Changes](#v03x--v050--package-layout--di-changes)
 - [v0.1.x → v0.2.0 — Autofac Integration](#v01x--v020--autofac-integration)
 - [v0.0.x → v0.1.x — Service Registration & Chrome Setup](#v00x--v01x--service-registration--chrome-setup)
+
+---
+
+## v0.7.2 → v0.7.3 — Unit of Work Helpers (BeginUnitOfWork + CommitOnSuccessAsync)
+
+### What changed
+
+Two new helpers on `SqlServiceBase` (so they're available on every typed
+repository and every custom service that extends it) that close a real
+gap: a parent repository method that didn't accept an `IUnitOfWork`
+parameter previously had no way to coordinate atomic writes across
+child repositories — each call opened its own connection and committed
+independently.
+
+| Helper | Shape | When to use |
+|---|---|---|
+| `BeginUnitOfWork(uow?)` → `UnitOfWorkScope` | Scope (`using` block + explicit `Commit()`) | Long methods, sequential statements, conditional returns |
+| `CommitOnSuccessAsync(work, uow?, ct?)` | Lambda (auto-commit on return / rollback on throw) | Short blocks; the whole transaction body fits in one expression |
+
+Both share the same caller-provides-or-we-own semantics — pick by code
+shape, not semantic.
+
+### When you DON'T need to migrate
+
+If your existing repository methods either (a) always receive an
+`IUnitOfWork` from the caller and pass it through, or (b) only do a
+single write and don't need to coordinate with child repos, nothing
+changes for you. The existing `IUnitOfWork? uow = null` parameter on
+every CoreLib repository method continues to work as before.
+
+### When you SHOULD migrate
+
+Any method that:
+
+1. Takes no `IUnitOfWork` parameter (or accepts an optional one), AND
+2. Calls into more than one repository / service to make changes that
+   should be atomic.
+
+Before:
+
+```csharp
+public bool UpdateAll(MyRow row)
+{
+    UpdateAsync(...).GetAwaiter().GetResult();          // connection #1
+    childRepo.UpdateChild(row.Id);                      // connection #2 — different transaction!
+    auditRepo.LogChange(row.Id, "updated");             // connection #3 — different transaction!
+    return true;
+}
+```
+
+After (long-method shape — `BeginUnitOfWork`):
+
+```csharp
+public async Task<bool> UpdateAllAsync(
+    MyRow row,
+    IUnitOfWork? uow = null,
+    CancellationToken ct = default)
+{
+    ArgumentNullException.ThrowIfNull(row);
+
+    using var scope = BeginUnitOfWork(uow);
+
+    await UpdateAsync(u => u
+        .Set(MyRow.Fields.Name, row.Name)
+        .Where(MyRow.Fields.Id == row.Id), uow: scope.Uow, ct: ct);
+
+    await childRepo.UpdateChildAsync(row.Id!.Value, uow: scope.Uow, ct: ct);
+    await auditRepo.LogChangeAsync(row.Id!.Value, "updated", uow: scope.Uow, ct: ct);
+
+    scope.Commit();   // explicit; forgetting this rolls back
+    return true;
+}
+```
+
+After (short-block shape — `CommitOnSuccessAsync`):
+
+```csharp
+public Task<bool> RenameAndStampAsync(
+    int id, string name,
+    IUnitOfWork? uow = null,
+    CancellationToken ct = default)
+{
+    return CommitOnSuccessAsync(async (txn, token) =>
+    {
+        await UpdateAsync(u => u.Set(MyRow.Fields.Name, name).Where(MyRow.Fields.Id == id),
+            uow: txn, ct: token);
+        await auditRepo.LogChangeAsync(id, "rename", uow: txn, ct: token);
+        return true;
+    }, uow, ct);
+}
+```
+
+### One trap to know
+
+When using `BeginUnitOfWork`, **every call inside the using block must
+pass `scope.Uow`**. If you forget on one call, that call opens its own
+connection and runs outside the transaction — silent atomicity bug. The
+lambda form has the same trap with `txn`. Code review should flag any
+repo call inside one of these blocks that doesn't thread the UoW
+through.
+
+### Sync wrappers
+
+Both `CommitOnSuccess<T>(Func<IUnitOfWork, T>, IUnitOfWork?)` and
+`CommitOnSuccess(Action<IUnitOfWork>, IUnitOfWork?)` exist and are
+marked `[Obsolete]` with the standard migration message. Use them only
+during the transition; prefer the async versions in new code.
 
 ---
 

--- a/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
+++ b/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Autofac</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <Description>Optional Autofac integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
+++ b/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Idevs.Net.CoreLib.Generators.Abstractions</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <PackageTags>Idevs; CoreLib; Roslyn; SourceGenerator; Helpers</PackageTags>
     <Description>Reusable Roslyn helpers for source generators that integrate with Idevs.Net.CoreLib's DI conventions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
+++ b/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Serilog</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <Description>Optional Serilog integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -4,3 +4,18 @@ Idevs.Repositories.UnitOfWorkScope.Dispose() -> void
 Idevs.Repositories.UnitOfWorkScope.DisposeAsync() -> System.Threading.Tasks.ValueTask
 Idevs.Repositories.UnitOfWorkScope.OwnsUnitOfWork.get -> bool
 Idevs.Repositories.UnitOfWorkScope.Uow.get -> Serenity.Data.IUnitOfWork
+Idevs.Repositories.SqlServiceBase.BeginUnitOfWork(Serenity.Data.IUnitOfWork uow = null) -> Idevs.Repositories.UnitOfWorkScope
+Idevs.Repositories.SqlServiceBase.CommitOnSuccessAsync<T>(System.Func<Serenity.Data.IUnitOfWork, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> work, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>
+Idevs.Repositories.SqlServiceBase.CommitOnSuccessAsync(System.Func<Serenity.Data.IUnitOfWork, System.Threading.CancellationToken, System.Threading.Tasks.Task> work, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Idevs.Repositories.SqlServiceBase.CommitOnSuccess<T>(System.Func<Serenity.Data.IUnitOfWork, T> work, Serenity.Data.IUnitOfWork uow = null) -> T
+Idevs.Repositories.SqlServiceBase.CommitOnSuccess(System.Action<Serenity.Data.IUnitOfWork> work, Serenity.Data.IUnitOfWork uow = null) -> void
+virtual Idevs.Repositories.RepositoryBase<TRow>.TryFirstAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateManyAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteManyAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RepositoryBase<TRow>.TryFirst(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> TRow
+virtual Idevs.Repositories.RepositoryBase<TRow>.Update(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateMany(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RepositoryBase<TRow>.Delete(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteMany(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null) -> int

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -1,10 +1,6 @@
-virtual Idevs.Repositories.RepositoryBase<TRow>.TryFirstAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
-virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateManyAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteManyAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.TryFirst(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> TRow
-virtual Idevs.Repositories.RepositoryBase<TRow>.Update(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateMany(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.Delete(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteMany(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null) -> int
+Idevs.Repositories.UnitOfWorkScope
+Idevs.Repositories.UnitOfWorkScope.Commit() -> void
+Idevs.Repositories.UnitOfWorkScope.Dispose() -> void
+Idevs.Repositories.UnitOfWorkScope.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Idevs.Repositories.UnitOfWorkScope.OwnsUnitOfWork.get -> bool
+Idevs.Repositories.UnitOfWorkScope.Uow.get -> Serenity.Data.IUnitOfWork

--- a/src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs
@@ -80,6 +80,94 @@ public abstract class SqlServiceBase
         return await work(connection, ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Acquire a unit of work for the duration of a <c>using</c> block.
+    /// </summary>
+    /// <remarks>
+    /// When <paramref name="uow"/> is supplied, the returned scope wraps it
+    /// without taking ownership — <see cref="UnitOfWorkScope.Commit"/> and
+    /// <see cref="UnitOfWorkScope.Dispose"/> are no-ops, the caller's outer
+    /// transaction wins. When <paramref name="uow"/> is null, the scope opens
+    /// a connection from <see cref="ConnectionKey"/> and a fresh
+    /// <see cref="UnitOfWork"/> on it; the caller MUST call
+    /// <see cref="UnitOfWorkScope.Commit"/> before the scope leaves the using
+    /// block, otherwise dispose rolls back. Use this form for long methods
+    /// with sequential statements, conditional branches, or early returns.
+    /// For short blocks, prefer <see cref="CommitOnSuccessAsync{T}"/>.
+    /// </remarks>
+    protected UnitOfWorkScope BeginUnitOfWork(IUnitOfWork? uow = null)
+    {
+        if (uow is not null)
+            return new UnitOfWorkScope(uow);
+
+        var connection = SqlConnections.NewByKey(ConnectionKey);
+        var newUow = new UnitOfWork(connection);
+        return new UnitOfWorkScope(connection, newUow);
+    }
+
+    /// <summary>
+    /// Run <paramref name="work"/> inside a unit of work; commit on success,
+    /// roll back on exception.
+    /// </summary>
+    /// <remarks>
+    /// If <paramref name="uow"/> is supplied, the caller's transaction is used
+    /// and this method does not commit/rollback — the caller wins. If null,
+    /// a fresh connection + UoW is opened, the work runs, and Commit() is
+    /// called when the work returns normally. If the work throws, Commit() is
+    /// skipped and the underlying scope rolls back via dispose.
+    /// </remarks>
+    protected async Task<T> CommitOnSuccessAsync<T>(
+        Func<IUnitOfWork, CancellationToken, Task<T>> work,
+        IUnitOfWork? uow = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        ct.ThrowIfCancellationRequested();
+
+        using var scope = BeginUnitOfWork(uow);
+        var result = await work(scope.Uow, ct).ConfigureAwait(false);
+        scope.Commit();
+        return result;
+    }
+
+    /// <summary>
+    /// Non-generic <see cref="CommitOnSuccessAsync{T}"/> overload for void work.
+    /// </summary>
+    protected async Task CommitOnSuccessAsync(
+        Func<IUnitOfWork, CancellationToken, Task> work,
+        IUnitOfWork? uow = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        ct.ThrowIfCancellationRequested();
+
+        using var scope = BeginUnitOfWork(uow);
+        await work(scope.Uow, ct).ConfigureAwait(false);
+        scope.Commit();
+    }
+
+    private const string ObsoleteSyncMessage =
+        "Sync wrapper kept for migration. Prefer the *Async variant. " +
+        "Will be removed once underlying SQL APIs become real-async (~1.0).";
+
+    /// <summary>Sync wrapper for <see cref="CommitOnSuccessAsync{T}"/>.</summary>
+    [Obsolete(ObsoleteSyncMessage)]
+    protected T CommitOnSuccess<T>(Func<IUnitOfWork, T> work, IUnitOfWork? uow = null)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        return CommitOnSuccessAsync((u, _) => Task.FromResult(work(u)), uow)
+            .GetAwaiter().GetResult();
+    }
+
+    /// <summary>Sync wrapper for the non-generic <see cref="CommitOnSuccessAsync(Func{IUnitOfWork, CancellationToken, Task}, IUnitOfWork?, CancellationToken)"/>.</summary>
+    [Obsolete(ObsoleteSyncMessage)]
+    protected void CommitOnSuccess(Action<IUnitOfWork> work, IUnitOfWork? uow = null)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        CommitOnSuccessAsync((u, _) => { work(u); return Task.CompletedTask; }, uow)
+            .GetAwaiter().GetResult();
+    }
+
     /// <summary>Creates a new <see cref="SqlQuery"/> pre-bound to this base's <see cref="Dialect"/>.</summary>
     protected SqlQuery SqlQuery() => new SqlQuery().Dialect(Dialect);
 

--- a/src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs
@@ -101,8 +101,19 @@ public abstract class SqlServiceBase
             return new UnitOfWorkScope(uow);
 
         var connection = SqlConnections.NewByKey(ConnectionKey);
-        var newUow = new UnitOfWork(connection);
-        return new UnitOfWorkScope(connection, newUow);
+        try
+        {
+            // BeginTransaction (called inside UnitOfWork's ctor) can throw —
+            // dispose the just-opened connection before propagating so we
+            // don't leak it.
+            var newUow = new UnitOfWork(connection);
+            return new UnitOfWorkScope(connection, newUow);
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Idevs.Net.CoreLib/Repositories/UnitOfWorkScope.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/UnitOfWorkScope.cs
@@ -1,0 +1,88 @@
+using System.Data;
+using Serenity.Data;
+
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Disposable scope around a <see cref="IUnitOfWork"/> created by
+/// <see cref="SqlServiceBase.BeginUnitOfWork"/>. Either wraps a caller-owned
+/// UoW (Commit/Dispose are no-ops) or owns a freshly opened connection +
+/// transaction (Commit must be called explicitly; Dispose rolls back when
+/// Commit was not called).
+/// </summary>
+/// <remarks>
+/// The explicit <see cref="Commit"/> requirement matches the
+/// <see cref="System.Transactions.TransactionScope"/> idiom — leaving the
+/// using block without calling Commit() is treated as failure and rolls back.
+/// </remarks>
+public sealed class UnitOfWorkScope : IDisposable, IAsyncDisposable
+{
+    private readonly IDbConnection? _ownedConnection;
+    private readonly UnitOfWork? _ownedUow;
+    private bool _committed;
+    private bool _disposed;
+
+    /// <summary>The unit of work to pass to repository calls.</summary>
+    public IUnitOfWork Uow { get; }
+
+    /// <summary>
+    /// True when this scope owns the connection + UoW it wraps. False when it
+    /// wraps a caller-owned UoW (in which case Commit/Dispose are no-ops).
+    /// </summary>
+    public bool OwnsUnitOfWork => _ownedUow is not null;
+
+    /// <summary>Wrap a caller-owned <see cref="IUnitOfWork"/>. Commit and Dispose are no-ops.</summary>
+    internal UnitOfWorkScope(IUnitOfWork callerUow)
+    {
+        Uow = callerUow ?? throw new ArgumentNullException(nameof(callerUow));
+        // Caller owns the transaction; nothing for this scope to commit or roll back.
+        _committed = true;
+    }
+
+    /// <summary>Take ownership of a freshly opened connection + new <see cref="UnitOfWork"/>.</summary>
+    internal UnitOfWorkScope(IDbConnection connection, UnitOfWork uow)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(uow);
+        _ownedConnection = connection;
+        _ownedUow = uow;
+        Uow = uow;
+    }
+
+    /// <summary>
+    /// Commit the owned transaction. No-op when this scope wraps a caller-owned
+    /// UoW or when Commit has already been called.
+    /// </summary>
+    public void Commit()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(UnitOfWorkScope));
+        if (_ownedUow is null || _committed) return;
+
+        _ownedUow.Commit();
+        _committed = true;
+    }
+
+    /// <summary>
+    /// Dispose the scope. Owned UoWs that were not committed are rolled back
+    /// (via the underlying <see cref="UnitOfWork"/> dispose). Wrapped caller
+    /// UoWs are left untouched.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Owned UoW: dispose triggers rollback if Commit was not called.
+        // Caller-owned UoW: nothing to do.
+        _ownedUow?.Dispose();
+        _ownedConnection?.Dispose();
+    }
+
+    /// <summary>Async dispose — current implementation is synchronous; provided for `await using` ergonomics.</summary>
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs
@@ -8,7 +8,7 @@ namespace Idevs.Net.CoreLib.Tests.Repositories;
 public class UnitOfWorkHelperTests
 {
     // Test subject that exposes BeginUnitOfWork / CommitOnSuccessAsync via a
-    // public surface. Overrides ExecuteAsync isn't needed because the helpers
+    // public surface. Overriding ExecuteAsync isn't needed because the helpers
     // talk to UnitOfWork directly.
     private sealed class TestService : Idevs.Repositories.RepositoryBase<TestSampleRow>
     {
@@ -165,5 +165,124 @@ public class UnitOfWorkHelperTests
         }, callerUow);
 
         Assert.True(ran);
+    }
+
+    // --- Owned-transaction commit/rollback path ---
+    //
+    // These tests exercise the path where uow == null, so the helper opens
+    // its own connection + UnitOfWork. We substitute IDbConnection +
+    // IDbTransaction and assert that BeginTransaction is called once and
+    // either Commit (success path) or Rollback (exception path) follows.
+
+    private static (ISqlConnections sqlConnections, IDbConnection connection, IDbTransaction transaction)
+        CreateOwnedTransactionFixture()
+    {
+        var transaction = Substitute.For<IDbTransaction>();
+        var connection = Substitute.For<IDbConnection>();
+        connection.BeginTransaction().Returns(transaction);
+        connection.State.Returns(ConnectionState.Open);
+        transaction.Connection.Returns(connection);
+
+        var sqlConnections = Substitute.For<ISqlConnections>();
+        sqlConnections.NewByKey(Arg.Any<string>()).Returns(connection);
+
+        return (sqlConnections, connection, transaction);
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_OwnedUow_CommitsTransactionOnSuccess()
+    {
+        var (sqlConnections, connection, transaction) = CreateOwnedTransactionFixture();
+        var service = new TestService(sqlConnections);
+
+        var result = await service.CommitOnSuccessAsync(
+            (u, _) => Task.FromResult("ok"));
+
+        Assert.Equal("ok", result);
+        connection.Received(1).BeginTransaction();
+        transaction.Received(1).Commit();
+        transaction.DidNotReceive().Rollback();
+        connection.Received().Dispose();
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_OwnedUow_DoesNotCommitOnException_AndDisposesEverything()
+    {
+        var (sqlConnections, connection, transaction) = CreateOwnedTransactionFixture();
+        var service = new TestService(sqlConnections);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CommitOnSuccessAsync<int>(
+                (_, _) => throw new InvalidOperationException("boom")));
+
+        connection.Received(1).BeginTransaction();
+        // Commit must NOT be called on the transaction when the work threw.
+        transaction.DidNotReceive().Commit();
+        // Serenity's UnitOfWork rolls back via transaction.Dispose() (the
+        // standard IDbTransaction contract: dispose without commit = rollback),
+        // not via an explicit Rollback() call. So we assert dispose chains:
+        // transaction disposed + connection disposed.
+        transaction.Received().Dispose();
+        connection.Received().Dispose();
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_OwnedUow_DisposeWithoutCommit_DisposesTransactionWithoutCommit()
+    {
+        var (sqlConnections, connection, transaction) = CreateOwnedTransactionFixture();
+        var service = new TestService(sqlConnections);
+
+        using (var scope = service.BeginUnitOfWork())
+        {
+            Assert.True(scope.OwnsUnitOfWork);
+            // Intentionally NOT calling scope.Commit() — leaving the using
+            // block without commit must NOT call Commit and must dispose
+            // the transaction (which rolls back per IDbTransaction contract).
+        }
+
+        connection.Received(1).BeginTransaction();
+        transaction.DidNotReceive().Commit();
+        transaction.Received().Dispose();
+        connection.Received().Dispose();
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_OwnedUow_ExplicitCommitThenDispose_CommitsExactlyOnce()
+    {
+        var (sqlConnections, connection, transaction) = CreateOwnedTransactionFixture();
+        var service = new TestService(sqlConnections);
+
+        using (var scope = service.BeginUnitOfWork())
+        {
+            scope.Commit();
+            // Calling Commit() again should be a no-op; final Commit count must still be 1.
+            scope.Commit();
+        }
+
+        transaction.Received(1).Commit();
+        connection.Received().Dispose();
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_BeginTransactionThrows_DisposesConnectionAndPropagates()
+    {
+        // Reproduces the leak the reviewer flagged: if creating the
+        // UnitOfWork (which calls connection.BeginTransaction internally)
+        // throws, BeginUnitOfWork must dispose the just-opened connection
+        // before propagating, not leak it.
+        var connection = Substitute.For<IDbConnection>();
+        connection.State.Returns(ConnectionState.Open);
+        connection
+            .When(c => c.BeginTransaction())
+            .Do(_ => throw new InvalidOperationException("transaction boom"));
+
+        var sqlConnections = Substitute.For<ISqlConnections>();
+        sqlConnections.NewByKey(Arg.Any<string>()).Returns(connection);
+        var service = new TestService(sqlConnections);
+
+        Assert.Throws<InvalidOperationException>(() => service.BeginUnitOfWork());
+
+        // The connection must have been disposed even though we never returned a scope.
+        connection.Received(1).Dispose();
     }
 }

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs
@@ -1,0 +1,169 @@
+using System.Data;
+using Idevs.Repositories;
+using NSubstitute;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Repositories;
+
+public class UnitOfWorkHelperTests
+{
+    // Test subject that exposes BeginUnitOfWork / CommitOnSuccessAsync via a
+    // public surface. Overrides ExecuteAsync isn't needed because the helpers
+    // talk to UnitOfWork directly.
+    private sealed class TestService : Idevs.Repositories.RepositoryBase<TestSampleRow>
+    {
+        public TestService(ISqlConnections c) : base(c) { }
+
+        // Re-expose protected helpers for direct testing.
+        public new UnitOfWorkScope BeginUnitOfWork(IUnitOfWork? uow = null) =>
+            base.BeginUnitOfWork(uow);
+
+        public new Task<T> CommitOnSuccessAsync<T>(
+            Func<IUnitOfWork, CancellationToken, Task<T>> work,
+            IUnitOfWork? uow = null,
+            CancellationToken ct = default) =>
+            base.CommitOnSuccessAsync(work, uow, ct);
+
+        public new Task CommitOnSuccessAsync(
+            Func<IUnitOfWork, CancellationToken, Task> work,
+            IUnitOfWork? uow = null,
+            CancellationToken ct = default) =>
+            base.CommitOnSuccessAsync(work, uow, ct);
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_WithCallerUow_ReturnsScopeWrappingIt()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+        var callerUow = new UnitOfWork(Substitute.For<IDbConnection>());
+
+        using var scope = service.BeginUnitOfWork(callerUow);
+
+        Assert.Same(callerUow, scope.Uow);
+        Assert.False(scope.OwnsUnitOfWork);
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_WithCallerUow_CommitIsNoOp()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+        var callerConnection = Substitute.For<IDbConnection>();
+        var callerUow = new UnitOfWork(callerConnection);
+
+        using (var scope = service.BeginUnitOfWork(callerUow))
+        {
+            scope.Commit(); // should not affect caller's UoW
+        }
+
+        // Caller's connection should NOT have been disposed by the scope.
+        callerConnection.DidNotReceive().Dispose();
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_WithoutUow_OwnsItAndOpensConnection()
+    {
+        var sqlConnections = Substitute.For<ISqlConnections>();
+        var connection = Substitute.For<IDbConnection>();
+        sqlConnections.NewByKey(Arg.Any<string>()).Returns(connection);
+        var service = new TestService(sqlConnections);
+
+        using (var scope = service.BeginUnitOfWork())
+        {
+            Assert.True(scope.OwnsUnitOfWork);
+            Assert.NotNull(scope.Uow);
+        }
+
+        // Owned connection should be disposed when the scope is.
+        connection.Received().Dispose();
+    }
+
+    [Fact]
+    public void BeginUnitOfWork_AfterDispose_CommitThrows()
+    {
+        var sqlConnections = Substitute.For<ISqlConnections>();
+        sqlConnections.NewByKey(Arg.Any<string>()).Returns(Substitute.For<IDbConnection>());
+        var service = new TestService(sqlConnections);
+
+        var scope = service.BeginUnitOfWork();
+        scope.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => scope.Commit());
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_WithCallerUow_PassesItThrough()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+        var callerUow = new UnitOfWork(Substitute.For<IDbConnection>());
+        IUnitOfWork? observed = null;
+
+        var result = await service.CommitOnSuccessAsync((u, _) =>
+        {
+            observed = u;
+            return Task.FromResult(42);
+        }, callerUow);
+
+        Assert.Equal(42, result);
+        Assert.Same(callerUow, observed);
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_NullWork_Throws()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            service.CommitOnSuccessAsync<int>(null!));
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_NonGeneric_NullWork_Throws()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            service.CommitOnSuccessAsync((Func<IUnitOfWork, CancellationToken, Task>)null!));
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_CancellationRequested_Throws()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            service.CommitOnSuccessAsync(
+                (u, _) => Task.FromResult(0),
+                uow: new UnitOfWork(Substitute.For<IDbConnection>()),
+                ct: cts.Token));
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_WorkThrows_RethrowsAndDoesNotSwallow()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+        var callerUow = new UnitOfWork(Substitute.For<IDbConnection>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.CommitOnSuccessAsync<int>(
+                (_, _) => throw new InvalidOperationException("boom"),
+                callerUow));
+    }
+
+    [Fact]
+    public async Task CommitOnSuccessAsync_NonGeneric_RunsAndReturns()
+    {
+        var service = new TestService(Substitute.For<ISqlConnections>());
+        var callerUow = new UnitOfWork(Substitute.For<IDbConnection>());
+        var ran = false;
+
+        await service.CommitOnSuccessAsync((u, _) =>
+        {
+            ran = true;
+            return Task.CompletedTask;
+        }, callerUow);
+
+        Assert.True(ran);
+    }
+}


### PR DESCRIPTION
## Summary

Closes a real gap PowerACC hit: a parent repository method that didn't accept an `IUnitOfWork` parameter previously had no way to coordinate atomic writes across child repositories. Each call opened its own connection and committed independently, breaking transaction atomicity.

This PR adds two helpers on `SqlServiceBase` (so they're available to every typed repository AND every custom service that extends it). Both share the same caller-provides-or-we-own semantics. Pick by code shape.

## API

| Helper | Shape | When to use |
|---|---|---|
| `BeginUnitOfWork(uow?)` → `UnitOfWorkScope` | Scope (`using` block + explicit `Commit()`) | Long methods, sequential statements, conditional returns |
| `CommitOnSuccessAsync(work, uow?, ct?)` | Lambda (auto-commit on return / rollback on throw) | Short blocks; the whole transaction body fits in one expression |

Both:
- When `uow` is supplied → use the caller's UoW; helpers never commit/dispose.
- When `uow` is null → open a fresh connection + UoW; commit on success, roll back on failure.

Plus sync `[Obsolete]` wrappers (`CommitOnSuccess<T>`, `CommitOnSuccess`) for the migration window.

## New public type

`Idevs.Repositories.UnitOfWorkScope` — `sealed`, `IDisposable`, `IAsyncDisposable`. Members: `Uow`, `OwnsUnitOfWork`, `Commit()`.

## Behavior matrix

| Caller passes `uow` | What happens |
|---|---|
| Yes | Helpers wrap it. `Commit()` is a no-op. `Dispose()` is a no-op. Caller's outer transaction wins. |
| No | Helpers open a connection + UoW. `BeginUnitOfWork` requires explicit `Commit()` (forgetting = rollback). `CommitOnSuccessAsync` auto-commits on lambda success / auto-rollback on throw. |

## Use cases

**Long block (was the original PowerACC pain point):**

```csharp
public async Task<bool> UpdateAllAsync(MyRow row,
    IUnitOfWork? uow = null, CancellationToken ct = default)
{
    ArgumentNullException.ThrowIfNull(row);

    using var scope = BeginUnitOfWork(uow);

    await UpdateAsync(u => u.Set(MyRow.Fields.Name, row.Name).Where(MyRow.Fields.Id == row.Id),
        uow: scope.Uow, ct: ct);
    await child1Repo.UpdateChild1Async(row.Id!.Value, uow: scope.Uow, ct: ct);
    await child2Repo.UpdateChild2Async(row.Id!.Value, uow: scope.Uow, ct: ct);
    var calc = await child3Repo.GetCalculatedAsync(row.Id!.Value, uow: scope.Uow, ct: ct);

    if (calc < 0) return false; // no Commit() → scope rolls back

    await UpdateAsync(u => u.Set(MyRow.Fields.CalculatedTotal, calc).Where(MyRow.Fields.Id == row.Id),
        uow: scope.Uow, ct: ct);

    scope.Commit();
    return true;
}
```

**Short block:**

```csharp
public Task<bool> RenameAndStampAsync(int id, string name,
    IUnitOfWork? uow = null, CancellationToken ct = default)
{
    return CommitOnSuccessAsync(async (txn, token) =>
    {
        await UpdateAsync(u => u.Set(MyRow.Fields.Name, name).Where(MyRow.Fields.Id == id),
            uow: txn, ct: token);
        await auditRepo.LogChangeAsync(id, "rename", uow: txn, ct: token);
        return true;
    }, uow, ct);
}
```

## Files

- `src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs` — added 4 protected methods + sync wrappers
- `src/Idevs.Net.CoreLib/Repositories/UnitOfWorkScope.cs` — new public type
- `src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt` — 6 entries for `UnitOfWorkScope`
- `tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs` — 10 dispatch + behavior tests
- `CHANGELOG.md` — 0.7.3 entry
- `MIGRATION.md` — 0.7.2 → 0.7.3 section
- All 4 packable csprojs — bumped to `0.7.3`

## Test plan

- [x] Build green on .NET 8 + .NET 10 (Release).
- [x] All 103 tests pass (was 93; +10 new for UoW helpers).
- [x] No new PublicAPI warnings.
- [ ] PR `Build & Test` check passes in CI.
- [ ] Copilot auto-review.
- [ ] After merge, `release.yml` packs all 4 packages and publishes 0.7.3 to nuget.org + creates `v0.7.3` GitHub Release.
- [ ] Smoke test in PowerACC: replace one cross-repo update method with the new pattern, verify atomicity.