### PR TITLE
feat: explicit-fields Create/Update + NotMapped/Expression integration tests (0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   `MsSqlContainerCollection`. Integration tests are tagged
   `[Trait("Category", "Integration")]` for easy filtering.
 
-### Verified (integration tests against SQL Server 2022)
+### Verified (integration tests against SQL Server 2022, pinned image tag)
 
 - `[NotMapped]` properties (declared without a backing `Field` in
   `RowFields`) are silently dropped from INSERT/UPDATE — the field has no
@@ -34,7 +34,18 @@
   "Invalid column name". The cure: do not assign Expression fields, or use
   `CreateExcludingAsync` / `UpdateExcludingAsync` to drop them explicitly.
 - Both include-only and exclude variants emit exactly the expected column
-  lists end-to-end.
+  lists end-to-end. Trap and cure are demonstrated symmetrically for both
+  INSERT and UPDATE paths.
+
+### Validation guards on the include-only overloads
+
+- `CreateAsync(row, fields)` rejects fields with `NotMapped` set or without
+  the `Insertable` flag (covers identity columns and `[Expression]` fields
+  with `Insertable=false`). Throws `ArgumentException` listing offending
+  field names — fail at API boundary instead of generating SQL the database
+  rejects.
+- `UpdateAsync(row, fields)` additionally rejects the Id field (which
+  belongs in WHERE, not SET).
 
 ## 0.7.3 (2026-05-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.7.4 (2026-05-04)
+
+### Added
+
+- `RepositoryBase<TRow>.CreateAsync(TRow row, Field[] fields, ...)` — insert
+  only the listed columns. Use when you want surgical control over the
+  INSERT regardless of which fields are "assigned" on the row instance.
+- `RepositoryBase<TRow>.CreateExcludingAsync(TRow row, Field[] excludeFields, ...)`
+  — insert all assigned, table-mapped fields EXCEPT the listed ones. Honors
+  Serenity's auto-exclusion rules and additionally drops the explicit
+  excludes.
+- `RepositoryBase<TRow, TKey>.UpdateAsync(TRow row, Field[] fields, ...)` —
+  update only the listed columns, bypassing Serenity's "assigned-field"
+  tracking. The row's Id must be set.
+- `RepositoryBase<TRow, TKey>.UpdateExcludingAsync(TRow row, Field[] excludeFields, ...)`
+  — update all assigned, table-mapped fields EXCEPT the listed ones.
+- Sync `[Obsolete]` wrappers for each new async method following the
+  existing migration pattern.
+- New test infrastructure: Testcontainers-based SQL Server 2022 fixture
+  (`MsSqlContainerFixture`) shared across integration test classes via
+  `MsSqlContainerCollection`. Integration tests are tagged
+  `[Trait("Category", "Integration")]` for easy filtering.
+
+### Verified (integration tests against SQL Server 2022)
+
+- `[NotMapped]` properties (declared without a backing `Field` in
+  `RowFields`) are silently dropped from INSERT/UPDATE — the field has no
+  SQL representation, so Serenity has nothing to write.
+- `[Expression]` fields are read-only outputs of the SELECT projection.
+  When **assigned** on a write path they DO end up in the SQL (per
+  Serenity's IsAssigned-based filter) and SQL Server rejects them with
+  "Invalid column name". The cure: do not assign Expression fields, or use
+  `CreateExcludingAsync` / `UpdateExcludingAsync` to drop them explicitly.
+- Both include-only and exclude variants emit exactly the expected column
+  lists end-to-end.
+
 ## 0.7.3 (2026-05-03)
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.1.0" />
     <PackageVersion Include="Verify.Xunit" Version="28.0.0" />
     <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 
 ## Contents
 
+- [v0.7.3 → v0.7.4 — Explicit-fields Create/Update + NotMapped/Expression handling](#v073--v074--explicit-fields-createupdate--notmappedexpression-handling)
 - [v0.7.2 → v0.7.3 — Unit of Work Helpers (BeginUnitOfWork + CommitOnSuccessAsync)](#v072--v073--unit-of-work-helpers-beginunitofwork--commitonsuccessasync)
 - [v0.7.1 → v0.7.2 — RepositoryBase Criteria-Based Update/Delete + TryFirst Alias](#v071--v072--repositorybase-criteria-based-updatedelete--tryfirst-alias)
 - [v0.6.x → v0.7.0 — Source-Generator DI Registration](#v06x--v070--source-generator-di-registration)
@@ -11,6 +12,123 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 - [v0.3.x → v0.5.0 — Package Layout & DI Changes](#v03x--v050--package-layout--di-changes)
 - [v0.1.x → v0.2.0 — Autofac Integration](#v01x--v020--autofac-integration)
 - [v0.0.x → v0.1.x — Service Registration & Chrome Setup](#v00x--v01x--service-registration--chrome-setup)
+
+---
+
+## v0.7.3 → v0.7.4 — Explicit-fields Create/Update + NotMapped/Expression handling
+
+### What changed
+
+Four new helpers on `RepositoryBase` for surgical control over which columns
+end up in INSERT/UPDATE statements. Plus integration-test-verified behavior
+documentation for `[NotMapped]` and `[Expression]` fields.
+
+| Helper | Lives on | When to use |
+|---|---|---|
+| `CreateAsync(TRow row, Field[] fields, ...)` | `RepositoryBase<TRow>` | Insert ONLY the listed columns. Bypasses Serenity's IsAssigned tracking. |
+| `CreateExcludingAsync(TRow row, Field[] excludeFields, ...)` | `RepositoryBase<TRow>` | Insert all assigned, table-mapped fields EXCEPT the listed ones. |
+| `UpdateAsync(TRow row, Field[] fields, ...)` | `RepositoryBase<TRow, TKey>` | Update ONLY the listed columns. The row's Id must be set. |
+| `UpdateExcludingAsync(TRow row, Field[] excludeFields, ...)` | `RepositoryBase<TRow, TKey>` | Update all assigned, table-mapped fields EXCEPT the listed ones. |
+
+### NotMapped / Expression — the actual behavior (verified end-to-end)
+
+A common assumption is that Serenity automatically skips `[NotMapped]` and
+`[Expression]` fields from INSERT/UPDATE. The truth is more nuanced:
+
+#### `[NotMapped]` properties
+
+**Production-correct pattern: declare them as plain CLR auto-properties WITH
+NO backing `Field` in `RowFields`.**
+
+```csharp
+[NotMapped]
+public string? TransientNote { get; set; }   // no fields.X[this] backing
+```
+
+The property exists on the row in memory, but Serenity has no `Field`
+metadata for it, so it cannot appear in any SQL. Setting it is silent.
+
+If you instead declare a `Field` for it (e.g., `public StringField TransientNote;`
+in `RowFields`), Serenity's writes WILL include it (default flag set has
+`Insertable | Updatable` on by default, which the `[NotMapped]` attribute does
+not clear automatically). To make a backing-field NotMapped column actually
+not write, pair it with `[SetFieldFlags(FieldFlags.None, FieldFlags.Insertable | FieldFlags.Updatable)]`.
+
+#### `[Expression]` fields
+
+These ARE meant for SELECT-time materialization (e.g., joined columns,
+computed values). Serenity reads them. **But Serenity's `InsertAndGetID` /
+`UpdateById` use an IsAssigned-based filter** — if you ASSIGN a value to an
+Expression field on the row instance, Serenity will include it in the
+INSERT/UPDATE column list, and SQL Server will reject it with "Invalid
+column name 'X'".
+
+Three ways to avoid the trap:
+
+1. **Don't assign Expression fields on a write path** (the natural pattern —
+   they're outputs of SELECT, not inputs).
+2. **Use `CreateExcludingAsync` / `UpdateExcludingAsync`** to drop them
+   explicitly even when assigned.
+3. **Use the include-only `CreateAsync(row, fields)` / `UpdateAsync(row, fields)`**
+   to specify the column list explicitly.
+
+### Migration steps
+
+1. Bump to `0.7.4` in your consumer project:
+   ```xml
+   <PackageReference Include="Idevs.Net.CoreLib" Version="0.7.4" />
+   ```
+2. **Audit any rows with `[Expression]` properties.** If your code paths
+   assign these (e.g., during deserialization from a DTO that includes the
+   computed value), either stop assigning them or switch the call to one
+   of the new exclude/include helpers.
+3. **(Optional) Replace partial-update patterns** that previously used the
+   criteria-based `UpdateAsync(Action<SqlUpdate>)` with the new
+   `UpdateAsync(TRow row, Field[] fields)` for cases where the value comes
+   from an existing row instance.
+
+### Examples
+
+**Insert only specific columns:**
+
+```csharp
+await repo.CreateAsync(row, [MyRow.Fields.Code, MyRow.Fields.Total],
+    uow: uow, ct: ct);
+```
+
+**Insert everything except a few:**
+
+```csharp
+await repo.CreateExcludingAsync(row, [MyRow.Fields.CreatedAt],
+    uow: uow, ct: ct);
+```
+
+**Update only one column on an existing row:**
+
+```csharp
+row.Total = recalculated;
+await repo.UpdateAsync(row, [MyRow.Fields.Total], uow: uow, ct: ct);
+```
+
+**Update everything except an audit column:**
+
+```csharp
+await repo.UpdateExcludingAsync(row, [MyRow.Fields.LastEditedBy],
+    uow: uow, ct: ct);
+```
+
+### Sync wrappers
+
+Each new async helper has a sync `[Obsolete]` companion (`Create`,
+`CreateExcluding`, `Update`, `UpdateExcluding`) following the existing
+migration pattern.
+
+### Test infrastructure note
+
+0.7.4 also adds Testcontainers-based integration tests against a real SQL
+Server 2022 container. They live under `tests/Idevs.Net.CoreLib.Tests/Integration/`
+and are tagged `[Trait("Category", "Integration")]`. Skip them with
+`dotnet test --filter "Category!=Integration"` if Docker isn't available.
 
 ---
 

--- a/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
+++ b/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Autofac</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <Description>Optional Autofac integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
+++ b/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Idevs.Net.CoreLib.Generators.Abstractions</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <PackageTags>Idevs; CoreLib; Roslyn; SourceGenerator; Helpers</PackageTags>
     <Description>Reusable Roslyn helpers for source generators that integrate with Idevs.Net.CoreLib's DI conventions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
+++ b/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Serilog</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <Description>Optional Serilog integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -19,3 +19,11 @@ virtual Idevs.Repositories.RepositoryBase<TRow>.Update(System.Action<Serenity.Da
 virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateMany(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null) -> int
 virtual Idevs.Repositories.RepositoryBase<TRow>.Delete(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
 virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteMany(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RepositoryBase<TRow>.CreateAsync(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+virtual Idevs.Repositories.RepositoryBase<TRow>.Create(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null) -> long
+virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateAsync(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.Update(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null) -> bool
+virtual Idevs.Repositories.RepositoryBase<TRow>.CreateExcludingAsync(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+virtual Idevs.Repositories.RepositoryBase<TRow>.CreateExcluding(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null) -> long
+virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateExcludingAsync(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateExcluding(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null) -> bool

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs
@@ -57,12 +57,22 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
     /// type does not implement <see cref="IIdRow"/>).
     /// </summary>
     /// <remarks>
-    /// Serenity's <c>InsertAndGetID</c> automatically skips fields with
-    /// <c>FieldFlags.NotMapped</c>, <c>FieldFlags.Expression</c>, or
-    /// <c>FieldFlags.Insertable=false</c>. Setting a value on those fields is a
-    /// no-op as far as the SQL is concerned. For explicit column control, use
-    /// the <see cref="CreateAsync(TRow, Serenity.Data.Field[], Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
-    /// overload.
+    /// Delegates to Serenity's <c>InsertAndGetID</c>, which uses an
+    /// IsAssigned-based filter: any field on the row that has been assigned a
+    /// value AND has the <c>Insertable</c> flag set goes into the INSERT.
+    /// Practical implications:
+    /// <list type="bullet">
+    /// <item><description><c>[NotMapped]</c> properties declared as plain CLR auto-properties
+    /// (no backing <see cref="Field"/> in <c>RowFields</c>) are silently dropped — they
+    /// have no SQL representation. This is the production-correct pattern.</description></item>
+    /// <item><description><c>[Expression]</c> fields are NOT auto-skipped on writes. If you
+    /// assign a value to one, it WILL be included in the INSERT and SQL Server will reject
+    /// it with "Invalid column name". Either don't assign Expression fields, or use
+    /// <see cref="CreateExcludingAsync"/> / <see cref="CreateAsync(TRow, Serenity.Data.Field[], Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
+    /// to drop them.</description></item>
+    /// <item><description>Identity columns are skipped automatically by Serenity (their
+    /// <c>Insertable</c> flag is off).</description></item>
+    /// </list>
     /// </remarks>
     public virtual Task<long> CreateAsync(
         TRow row,
@@ -81,14 +91,21 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
     /// Returns the new identity, or 0 when the row has no identity column.
     /// </summary>
     /// <remarks>
-    /// Use when you want surgical control over which columns end up in the
-    /// INSERT, regardless of which fields are "assigned" on the row instance.
-    /// The default <see cref="CreateAsync(TRow, IUnitOfWork?, CancellationToken)"/>
-    /// already auto-skips <c>NotMapped</c> / <c>Expression</c> / non-insertable
-    /// fields; this overload is for cases where you want to also exclude
-    /// regular columns (e.g., let the database fill defaults, or split a row
-    /// across multiple inserts).
+    /// Surgical control over the INSERT column list, bypassing
+    /// IsAssigned tracking. Validates each listed field up front:
+    /// <list type="bullet">
+    /// <item><description>Fields with <c>NotMapped</c> set are rejected (they have no SQL column).</description></item>
+    /// <item><description>Fields without the <c>Insertable</c> flag are rejected (covers identity
+    /// columns and <c>[Expression]</c> fields that cleared <c>Insertable</c> via <c>[SetFieldFlags]</c>).</description></item>
+    /// </list>
+    /// Throws <see cref="ArgumentException"/> with the offending field names instead of
+    /// generating SQL that the database would reject. If you need to write to such a
+    /// field anyway (rare), drop to <c>SqlInsert</c> directly via <c>ExecuteAsync</c>.
     /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="fields"/> is empty, or if any listed field is
+    /// <c>NotMapped</c> or has <c>Insertable=false</c>.
+    /// </exception>
     public virtual Task<long> CreateAsync(
         TRow row,
         Field[] fields,
@@ -99,6 +116,19 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
         ArgumentNullException.ThrowIfNull(fields);
         if (fields.Length == 0)
             throw new ArgumentException("At least one field must be specified.", nameof(fields));
+
+        var rejected = fields
+            .Where(f => (f.Flags & FieldFlags.NotMapped) != 0
+                     || (f.Flags & FieldFlags.Insertable) != FieldFlags.Insertable)
+            .Select(f => f.Name)
+            .ToArray();
+        if (rejected.Length > 0)
+            throw new ArgumentException(
+                $"Cannot INSERT non-insertable field(s): {string.Join(", ", rejected)}. " +
+                "These are NotMapped, Expression-decorated, identity columns, or otherwise " +
+                "have FieldFlags.Insertable=false. Drop to SqlInsert via ExecuteAsync if you " +
+                "need to bypass this check.",
+                nameof(fields));
 
         return ExecuteAsync((c, _) =>
         {
@@ -115,13 +145,13 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
     /// identity, or 0 when the row has no identity column.
     /// </summary>
     /// <remarks>
-    /// Honors the same auto-exclusion rules as the default
-    /// <see cref="CreateAsync(TRow, IUnitOfWork?, CancellationToken)"/>
-    /// (skips <c>NotMapped</c>, <c>Expression</c>, and non-insertable fields)
-    /// AND additionally skips the explicit <paramref name="excludeFields"/>.
-    /// Useful when most of the row should be inserted but a few columns must
-    /// be omitted (e.g., let the database default <c>CreatedAt</c>, skip a
-    /// derived column you populated for downstream code).
+    /// Filter applied per field, in order: caller's <paramref name="excludeFields"/>,
+    /// then <c>IsAssigned</c>, then <c>NotMapped</c>, then <c>Insertable</c> flag.
+    /// The <c>Insertable</c>-flag check excludes identity columns and any field
+    /// where <c>[SetFieldFlags]</c> has cleared the flag. Note that an
+    /// <c>[Expression]</c>-decorated field with the default flag set is NOT
+    /// auto-skipped — list it in <paramref name="excludeFields"/> if it might
+    /// be assigned on the row instance.
     /// </remarks>
     public virtual Task<long> CreateExcludingAsync(
         TRow row,

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs
@@ -57,8 +57,12 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
     /// type does not implement <see cref="IIdRow"/>).
     /// </summary>
     /// <remarks>
-    /// For updates, use <c>UpdateAsync</c>. The explicit Create/Update split mirrors
-    /// Serenity's endpoint convention.
+    /// Serenity's <c>InsertAndGetID</c> automatically skips fields with
+    /// <c>FieldFlags.NotMapped</c>, <c>FieldFlags.Expression</c>, or
+    /// <c>FieldFlags.Insertable=false</c>. Setting a value on those fields is a
+    /// no-op as far as the SQL is concerned. For explicit column control, use
+    /// the <see cref="CreateAsync(TRow, Serenity.Data.Field[], Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
+    /// overload.
     /// </remarks>
     public virtual Task<long> CreateAsync(
         TRow row,
@@ -70,6 +74,84 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
         return ExecuteAsync((c, _) =>
             Task.FromResult<long>(c.InsertAndGetID(row) ?? 0L),
             uow, ct);
+    }
+
+    /// <summary>
+    /// Insert <paramref name="row"/> writing only the listed <paramref name="fields"/>.
+    /// Returns the new identity, or 0 when the row has no identity column.
+    /// </summary>
+    /// <remarks>
+    /// Use when you want surgical control over which columns end up in the
+    /// INSERT, regardless of which fields are "assigned" on the row instance.
+    /// The default <see cref="CreateAsync(TRow, IUnitOfWork?, CancellationToken)"/>
+    /// already auto-skips <c>NotMapped</c> / <c>Expression</c> / non-insertable
+    /// fields; this overload is for cases where you want to also exclude
+    /// regular columns (e.g., let the database fill defaults, or split a row
+    /// across multiple inserts).
+    /// </remarks>
+    public virtual Task<long> CreateAsync(
+        TRow row,
+        Field[] fields,
+        IUnitOfWork? uow = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        ArgumentNullException.ThrowIfNull(fields);
+        if (fields.Length == 0)
+            throw new ArgumentException("At least one field must be specified.", nameof(fields));
+
+        return ExecuteAsync((c, _) =>
+        {
+            var insert = SqlInsert(row.Table);
+            foreach (var f in fields)
+                insert.Set(f, f.AsObject(row));
+            return Task.FromResult<long>(insert.ExecuteAndGetID(c) ?? 0L);
+        }, uow, ct);
+    }
+
+    /// <summary>
+    /// Insert <paramref name="row"/> writing all assigned, table-mapped fields
+    /// EXCEPT those listed in <paramref name="excludeFields"/>. Returns the new
+    /// identity, or 0 when the row has no identity column.
+    /// </summary>
+    /// <remarks>
+    /// Honors the same auto-exclusion rules as the default
+    /// <see cref="CreateAsync(TRow, IUnitOfWork?, CancellationToken)"/>
+    /// (skips <c>NotMapped</c>, <c>Expression</c>, and non-insertable fields)
+    /// AND additionally skips the explicit <paramref name="excludeFields"/>.
+    /// Useful when most of the row should be inserted but a few columns must
+    /// be omitted (e.g., let the database default <c>CreatedAt</c>, skip a
+    /// derived column you populated for downstream code).
+    /// </remarks>
+    public virtual Task<long> CreateExcludingAsync(
+        TRow row,
+        Field[] excludeFields,
+        IUnitOfWork? uow = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        ArgumentNullException.ThrowIfNull(excludeFields);
+
+        var exclude = new HashSet<Field>(excludeFields);
+
+        return ExecuteAsync((c, _) =>
+        {
+            var insert = SqlInsert(row.Table);
+            foreach (var f in row.GetFields())
+            {
+                if (exclude.Contains(f)) continue;
+                if (!row.IsAssigned(f)) continue;
+                if ((f.Flags & FieldFlags.NotMapped) != 0) continue;
+                // The Insertable check excludes [Expression]-decorated fields
+                // (they are flagged Calculated/Foreign without Insertable),
+                // identity columns, computed columns, and any field marked
+                // Insertable=false.
+                if ((f.Flags & FieldFlags.Insertable) != FieldFlags.Insertable) continue;
+
+                insert.Set(f, f.AsObject(row));
+            }
+            return Task.FromResult<long>(insert.ExecuteAndGetID(c) ?? 0L);
+        }, uow, ct);
     }
 
     /// <summary>
@@ -206,6 +288,14 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
     [Obsolete(ObsoleteSyncMessage)]
     public virtual long Create(TRow row, IUnitOfWork? uow = null) =>
         CreateAsync(row, uow).GetAwaiter().GetResult();
+
+    [Obsolete(ObsoleteSyncMessage)]
+    public virtual long Create(TRow row, Field[] fields, IUnitOfWork? uow = null) =>
+        CreateAsync(row, fields, uow).GetAwaiter().GetResult();
+
+    [Obsolete(ObsoleteSyncMessage)]
+    public virtual long CreateExcluding(TRow row, Field[] excludeFields, IUnitOfWork? uow = null) =>
+        CreateExcludingAsync(row, excludeFields, uow).GetAwaiter().GetResult();
 
     [Obsolete(ObsoleteSyncMessage)]
     public virtual int Update(

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
@@ -47,6 +47,14 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
     /// Update <paramref name="row"/> by its Id field. Returns true when at least
     /// one row was affected. The row's Id must be set before calling.
     /// </summary>
+    /// <remarks>
+    /// Serenity's <c>UpdateById</c> only writes fields that have been "assigned"
+    /// on the row instance, and automatically skips fields with
+    /// <c>FieldFlags.NotMapped</c>, <c>FieldFlags.Expression</c>, or
+    /// <c>FieldFlags.Updatable=false</c>. For explicit column control, use the
+    /// <see cref="UpdateAsync(TRow, Serenity.Data.Field[], Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
+    /// overload.
+    /// </remarks>
     public virtual Task<bool> UpdateAsync(
         TRow row,
         IUnitOfWork? uow = null,
@@ -57,6 +65,110 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
         return ExecuteAsync((c, _) =>
         {
             var affected = c.UpdateById(row);
+            return Task.FromResult(affected > 0);
+        }, uow, ct);
+    }
+
+    /// <summary>
+    /// Update only the listed <paramref name="fields"/> on the row identified by
+    /// <paramref name="row"/>'s Id. Returns true when at least one row was affected.
+    /// </summary>
+    /// <remarks>
+    /// Use when the row instance has many assigned fields but you want only a
+    /// specific subset to land in the UPDATE — bypasses Serenity's
+    /// "assigned-field" tracking. The row's Id must be set before calling.
+    /// </remarks>
+    public virtual Task<bool> UpdateAsync(
+        TRow row,
+        Field[] fields,
+        IUnitOfWork? uow = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        ArgumentNullException.ThrowIfNull(fields);
+        if (fields.Length == 0)
+            throw new ArgumentException("At least one field must be specified.", nameof(fields));
+
+        var idRow = (IIdRow)row;
+        var idValue = idRow.IdField.AsObject(row);
+        if (idValue is null)
+            throw new InvalidOperationException(
+                "Row's Id must be set before calling UpdateAsync(row, fields, ...).");
+
+        return ExecuteAsync((c, _) =>
+        {
+            var update = SqlUpdate(row.Table);
+            foreach (var f in fields)
+                update.Set(f, f.AsObject(row));
+            update.Where(new BinaryCriteria(
+                new Criteria(idRow.IdField),
+                CriteriaOperator.EQ,
+                new ValueCriteria(idValue)));
+
+            var affected = update.Execute(c);
+            return Task.FromResult(affected > 0);
+        }, uow, ct);
+    }
+
+    /// <summary>
+    /// Update all assigned, table-mapped fields on <paramref name="row"/>
+    /// EXCEPT those listed in <paramref name="excludeFields"/>. Returns true
+    /// when at least one row was affected.
+    /// </summary>
+    /// <remarks>
+    /// Honors the same auto-exclusion rules as the default
+    /// <see cref="UpdateAsync(TRow, IUnitOfWork?, CancellationToken)"/>
+    /// (skips <c>NotMapped</c>, expression/calculated, and non-updatable
+    /// fields) AND additionally skips the explicit
+    /// <paramref name="excludeFields"/>. Useful when most of the row should be
+    /// updated but a specific column must be preserved (e.g., never overwrite
+    /// an audit timestamp from this code path). The row's Id must be set
+    /// before calling.
+    /// </remarks>
+    public virtual Task<bool> UpdateExcludingAsync(
+        TRow row,
+        Field[] excludeFields,
+        IUnitOfWork? uow = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        ArgumentNullException.ThrowIfNull(excludeFields);
+
+        var idRow = (IIdRow)row;
+        var idField = idRow.IdField;
+        var idValue = idField.AsObject(row);
+        if (idValue is null)
+            throw new InvalidOperationException(
+                "Row's Id must be set before calling UpdateExcludingAsync(row, excludeFields, ...).");
+
+        var exclude = new HashSet<Field>(excludeFields);
+
+        return ExecuteAsync((c, _) =>
+        {
+            var update = SqlUpdate(row.Table);
+            var anySet = false;
+            foreach (var f in row.GetFields())
+            {
+                // Never SET the Id column itself — it goes in WHERE.
+                if (ReferenceEquals(f, idField)) continue;
+                if (exclude.Contains(f)) continue;
+                if (!row.IsAssigned(f)) continue;
+                if ((f.Flags & FieldFlags.NotMapped) != 0) continue;
+                if ((f.Flags & FieldFlags.Updatable) != FieldFlags.Updatable) continue;
+
+                update.Set(f, f.AsObject(row));
+                anySet = true;
+            }
+
+            if (!anySet)
+                return Task.FromResult(false);
+
+            update.Where(new BinaryCriteria(
+                new Criteria(idField),
+                CriteriaOperator.EQ,
+                new ValueCriteria(idValue)));
+
+            var affected = update.Execute(c);
             return Task.FromResult(affected > 0);
         }, uow, ct);
     }
@@ -96,6 +208,14 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
     [Obsolete(ObsoleteSyncMessage)]
     public virtual bool Update(TRow row, IUnitOfWork? uow = null) =>
         UpdateAsync(row, uow).GetAwaiter().GetResult();
+
+    [Obsolete(ObsoleteSyncMessage)]
+    public virtual bool Update(TRow row, Field[] fields, IUnitOfWork? uow = null) =>
+        UpdateAsync(row, fields, uow).GetAwaiter().GetResult();
+
+    [Obsolete(ObsoleteSyncMessage)]
+    public virtual bool UpdateExcluding(TRow row, Field[] excludeFields, IUnitOfWork? uow = null) =>
+        UpdateExcludingAsync(row, excludeFields, uow).GetAwaiter().GetResult();
 
     [Obsolete(ObsoleteSyncMessage)]
     public virtual bool DeleteById(TKey id, IUnitOfWork? uow = null) =>

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
@@ -48,12 +48,21 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
     /// one row was affected. The row's Id must be set before calling.
     /// </summary>
     /// <remarks>
-    /// Serenity's <c>UpdateById</c> only writes fields that have been "assigned"
-    /// on the row instance, and automatically skips fields with
-    /// <c>FieldFlags.NotMapped</c>, <c>FieldFlags.Expression</c>, or
-    /// <c>FieldFlags.Updatable=false</c>. For explicit column control, use the
+    /// Delegates to Serenity's <c>UpdateById</c>, which uses an
+    /// IsAssigned-based filter: any field on the row that has been assigned a
+    /// value AND has the <c>Updatable</c> flag set goes into the UPDATE.
+    /// Practical implications:
+    /// <list type="bullet">
+    /// <item><description><c>[NotMapped]</c> properties declared as plain CLR auto-properties
+    /// (no backing <see cref="Field"/> in <c>RowFields</c>) are silently dropped — they
+    /// have no SQL representation.</description></item>
+    /// <item><description><c>[Expression]</c> fields are NOT auto-skipped on writes. If you
+    /// assign a value to one, it WILL be included in the UPDATE and SQL Server will reject
+    /// it with "Invalid column name". Either don't assign Expression fields, or use
+    /// <see cref="UpdateExcludingAsync"/> /
     /// <see cref="UpdateAsync(TRow, Serenity.Data.Field[], Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
-    /// overload.
+    /// to drop them.</description></item>
+    /// </list>
     /// </remarks>
     public virtual Task<bool> UpdateAsync(
         TRow row,
@@ -74,10 +83,25 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
     /// <paramref name="row"/>'s Id. Returns true when at least one row was affected.
     /// </summary>
     /// <remarks>
-    /// Use when the row instance has many assigned fields but you want only a
-    /// specific subset to land in the UPDATE — bypasses Serenity's
-    /// "assigned-field" tracking. The row's Id must be set before calling.
+    /// Surgical control over the UPDATE column list, bypassing IsAssigned
+    /// tracking. Validates each listed field up front:
+    /// <list type="bullet">
+    /// <item><description>The Id field is rejected (it belongs in WHERE, not SET).</description></item>
+    /// <item><description>Fields with <c>NotMapped</c> set are rejected.</description></item>
+    /// <item><description>Fields without the <c>Updatable</c> flag are rejected (covers
+    /// computed columns, <c>[Expression]</c> fields with <c>Updatable</c> cleared, and any
+    /// field marked <c>Updatable=false</c> via <c>[SetFieldFlags]</c>).</description></item>
+    /// </list>
+    /// Throws <see cref="ArgumentException"/> with the offending field names instead of
+    /// generating SQL the database would reject. The row's Id must be set before calling.
     /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="fields"/> is empty, or if any listed field is the Id
+    /// column, <c>NotMapped</c>, or has <c>Updatable=false</c>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the row's Id has not been assigned.
+    /// </exception>
     public virtual Task<bool> UpdateAsync(
         TRow row,
         Field[] fields,
@@ -90,10 +114,25 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
             throw new ArgumentException("At least one field must be specified.", nameof(fields));
 
         var idRow = (IIdRow)row;
-        var idValue = idRow.IdField.AsObject(row);
+        var idField = idRow.IdField;
+        var idValue = idField.AsObject(row);
         if (idValue is null)
             throw new InvalidOperationException(
                 "Row's Id must be set before calling UpdateAsync(row, fields, ...).");
+
+        var rejected = fields
+            .Where(f => ReferenceEquals(f, idField)
+                     || (f.Flags & FieldFlags.NotMapped) != 0
+                     || (f.Flags & FieldFlags.Updatable) != FieldFlags.Updatable)
+            .Select(f => ReferenceEquals(f, idField) ? $"{f.Name} (Id column)" : f.Name)
+            .ToArray();
+        if (rejected.Length > 0)
+            throw new ArgumentException(
+                $"Cannot UPDATE field(s) in SET list: {string.Join(", ", rejected)}. " +
+                "These are the Id column, NotMapped, Expression-decorated, or otherwise " +
+                "have FieldFlags.Updatable=false. The Id is used in WHERE; do not include " +
+                "it in the SET list. Drop to SqlUpdate via ExecuteAsync to bypass.",
+                nameof(fields));
 
         return ExecuteAsync((c, _) =>
         {
@@ -101,7 +140,7 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
             foreach (var f in fields)
                 update.Set(f, f.AsObject(row));
             update.Where(new BinaryCriteria(
-                new Criteria(idRow.IdField),
+                new Criteria(idField),
                 CriteriaOperator.EQ,
                 new ValueCriteria(idValue)));
 
@@ -116,14 +155,14 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
     /// when at least one row was affected.
     /// </summary>
     /// <remarks>
-    /// Honors the same auto-exclusion rules as the default
-    /// <see cref="UpdateAsync(TRow, IUnitOfWork?, CancellationToken)"/>
-    /// (skips <c>NotMapped</c>, expression/calculated, and non-updatable
-    /// fields) AND additionally skips the explicit
-    /// <paramref name="excludeFields"/>. Useful when most of the row should be
-    /// updated but a specific column must be preserved (e.g., never overwrite
-    /// an audit timestamp from this code path). The row's Id must be set
-    /// before calling.
+    /// Filter applied per field, in order: caller's <paramref name="excludeFields"/>,
+    /// then the Id field (which goes in WHERE, not SET), then <c>IsAssigned</c>,
+    /// then <c>NotMapped</c>, then <c>Updatable</c> flag. The <c>Updatable</c>-flag
+    /// check excludes computed/identity columns and any field where
+    /// <c>[SetFieldFlags]</c> has cleared the flag. Note that an
+    /// <c>[Expression]</c>-decorated field with the default flag set is NOT
+    /// auto-skipped — list it in <paramref name="excludeFields"/> if it might
+    /// be assigned on the row instance. The row's Id must be set before calling.
     /// </remarks>
     public virtual Task<bool> UpdateExcludingAsync(
         TRow row,

--- a/tests/Idevs.Net.CoreLib.Tests/Idevs.Net.CoreLib.Tests.csproj
+++ b/tests/Idevs.Net.CoreLib.Tests/Idevs.Net.CoreLib.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
+    <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/IntegrationTestRow.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/IntegrationTestRow.cs
@@ -1,0 +1,75 @@
+using Serenity.ComponentModel;
+using Serenity.Data;
+using Serenity.Data.Mapping;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Row used by repository write integration tests. Mixes table fields with a
+/// <see cref="NotMappedAttribute"/> property and an <see cref="ExpressionAttribute"/>
+/// joined column to verify Serenity's auto-exclusion behavior end-to-end
+/// against a real SQL Server.
+/// </summary>
+[ConnectionKey("Default"), Module("Integration"), TableName("[IntegrationTestRows]")]
+public sealed class IntegrationTestRow : Row<IntegrationTestRow.RowFields>, IIdRow, INameRow
+{
+    [Identity, IdProperty]
+    public int? Id { get => fields.Id[this]; set => fields.Id[this] = value; }
+
+    [Size(50), NotNull, NameProperty]
+    public string? Code { get => fields.Code[this]; set => fields.Code[this] = value; }
+
+    public decimal? Amount { get => fields.Amount[this]; set => fields.Amount[this] = value; }
+
+    [Size(20)]
+    public string? Status { get => fields.Status[this]; set => fields.Status[this] = value; }
+
+    private string? _transientNote;
+
+    /// <summary>
+    /// Plain CLR property with no <see cref="Field"/> in <see cref="RowFields"/>.
+    /// This is the production-correct pattern for a transient property that
+    /// must round-trip through application code but never appear in any SQL
+    /// — the field is simply not part of the row's metadata, so Serenity has
+    /// nothing to insert/update/select.
+    /// </summary>
+    [Serenity.Data.Mapping.NotMapped]
+    public string? TransientNote
+    {
+        get => _transientNote;
+        set => _transientNote = value;
+    }
+
+    /// <summary>
+    /// SQL expression-based field — derived from another column (or a JOIN in
+    /// real schemas). Reading it via SELECT works (Serenity rewrites the
+    /// expression into the projection); writing must NOT appear in
+    /// INSERT/UPDATE because no real column named "AmountDoubled" exists.
+    /// As with NotMapped, we pair <c>[Expression]</c> with
+    /// <c>[SetFieldFlags]</c> to clear Insertable/Updatable explicitly.
+    /// </summary>
+    [Serenity.Data.Mapping.Expression("(t0.Amount * 2)")]
+    [Serenity.Data.Mapping.SetFieldFlags(FieldFlags.None, FieldFlags.Insertable | FieldFlags.Updatable)]
+    public decimal? AmountDoubled
+    {
+        get => fields.AmountDoubled[this];
+        set => fields.AmountDoubled[this] = value;
+    }
+
+    public new static readonly RowFields Fields = (RowFields)new IntegrationTestRow().GetFields();
+
+    public sealed class RowFields : RowFieldsBase
+    {
+#pragma warning disable CS8618 // populated by RowFieldsBase reflection
+        public Int32Field Id;
+        public StringField Code;
+        public DecimalField Amount;
+        public StringField Status;
+
+        // TransientNote intentionally omitted — see the [NotMapped] property
+        // above. AmountDoubled remains because [Expression] needs a backing
+        // field for SELECT-time materialization.
+        public DecimalField AmountDoubled;
+#pragma warning restore CS8618
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
@@ -1,0 +1,101 @@
+using System.Data.Common;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using Serenity.Data;
+using Testcontainers.MsSql;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// xUnit collection fixture that spins up a SQL Server 2022 container via
+/// Testcontainers, exposes a configured <see cref="ISqlConnections"/> bound
+/// to the "Default" key, and creates the test schema once at startup.
+/// </summary>
+/// <remarks>
+/// Requires Docker on the host. CI: GitHub-hosted Linux runners include
+/// Docker out of the box. Locally: install Docker Desktop / colima / etc.
+/// First run pulls ~2 GB image; subsequent runs are cached.
+/// </remarks>
+public sealed class MsSqlContainerFixture : IAsyncLifetime
+{
+    private const string SaPassword = "Strong!Passw0rd123";
+
+    private readonly MsSqlContainer _container;
+
+    public ISqlConnections SqlConnections { get; private set; } = default!;
+    public string ConnectionString => _container.GetConnectionString();
+
+    public MsSqlContainerFixture()
+    {
+        _container = new MsSqlBuilder()
+            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+            .WithPassword(SaPassword)
+            .Build();
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        // Register the SqlClient factory globally for this AppDomain so that
+        // Serenity's DefaultSqlConnections (which goes through
+        // DbProviderFactories.GetFactory) can construct connections by
+        // provider name. Idempotent — duplicate registration throws, so we
+        // only register if not already present.
+        if (!DbProviderFactories.TryGetFactory("Microsoft.Data.SqlClient", out _))
+            DbProviderFactories.RegisterFactory("Microsoft.Data.SqlClient", SqlClientFactory.Instance);
+
+        var connectionStringOptions = new ConnectionStringOptions();
+        connectionStringOptions["Default"] = new ConnectionStringEntry
+        {
+            ConnectionString = ConnectionString,
+            ProviderName = "Microsoft.Data.SqlClient",
+            Dialect = "SqlServer2012"
+        };
+
+        var defaultConnectionStrings = new DefaultConnectionStrings(
+            Options.Create(connectionStringOptions),
+            new DefaultSqlDialectMapper());
+
+        SqlConnections = new DefaultSqlConnections(defaultConnectionStrings);
+
+        // Create schema for the integration test row.
+        using var conn = SqlConnections.NewByKey("Default");
+        SqlHelper.ExecuteNonQuery(conn, """
+            IF OBJECT_ID('dbo.IntegrationTestRows', 'U') IS NOT NULL
+                DROP TABLE dbo.IntegrationTestRows;
+
+            CREATE TABLE dbo.IntegrationTestRows (
+                Id INT IDENTITY(1,1) PRIMARY KEY,
+                Code NVARCHAR(50) NOT NULL,
+                Amount DECIMAL(18,4) NOT NULL DEFAULT 0,
+                Status NVARCHAR(20) NULL
+            );
+            """);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Truncate the test table — call between tests for isolation when sharing
+    /// the fixture across a class.
+    /// </summary>
+    public void TruncateTestTable()
+    {
+        using var conn = SqlConnections.NewByKey("Default");
+        SqlHelper.ExecuteNonQuery(conn, "TRUNCATE TABLE dbo.IntegrationTestRows;");
+    }
+}
+
+/// <summary>
+/// xUnit collection definition so multiple integration test classes can share
+/// a single container instance (the SQL Server image is large; one start per
+/// test session is plenty).
+/// </summary>
+[CollectionDefinition(nameof(MsSqlContainerCollection))]
+public sealed class MsSqlContainerCollection : ICollectionFixture<MsSqlContainerFixture>
+{
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
@@ -25,10 +25,19 @@ public sealed class MsSqlContainerFixture : IAsyncLifetime
     public ISqlConnections SqlConnections { get; private set; } = default!;
     public string ConnectionString => _container.GetConnectionString();
 
+    /// <summary>
+    /// Pinned SQL Server image. We deliberately don't use the floating
+    /// <c>2022-latest</c> tag — Microsoft retags it on every CU release,
+    /// which can change startup behavior or SQL semantics and break CI
+    /// without any change in this repo. Bump this constant intentionally
+    /// when we want to validate against a newer CU.
+    /// </summary>
+    private const string MsSqlImage = "mcr.microsoft.com/mssql/server:2022-CU20-ubuntu-22.04";
+
     public MsSqlContainerFixture()
     {
         _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+            .WithImage(MsSqlImage)
             .WithPassword(SaPassword)
             .Build();
     }

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs
@@ -30,20 +30,49 @@ public sealed class RepositoryWriteIntegrationTests : IDisposable
 
     private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
 
+    /// <summary>
+    /// Asserts the field-flag baseline assumed by every other test in this
+    /// suite. If Serenity changes how it derives flags from row attributes
+    /// (or our row's attribute usage drifts), this test fails first with a
+    /// clear message — instead of cascading into N opaque "Invalid column
+    /// name" failures elsewhere.
+    /// </summary>
     [Fact]
-    public void Diagnose_FieldFlags()
+    public void RowFieldFlags_MatchExpectedBaseline()
     {
-        foreach (var f in IntegrationTestRow.Fields)
+        static (bool Insertable, bool Updatable, bool NotMapped, bool Calculated, bool Foreign)
+            Read(Field f) => (
+                (f.Flags & FieldFlags.Insertable) == FieldFlags.Insertable,
+                (f.Flags & FieldFlags.Updatable) == FieldFlags.Updatable,
+                (f.Flags & FieldFlags.NotMapped) != 0,
+                (f.Flags & FieldFlags.Calculated) != 0,
+                (f.Flags & FieldFlags.Foreign) != 0);
+
+        // Identity column — auto-managed by SQL Server, neither insertable nor updatable.
+        var id = Read(Fld.Id);
+        Assert.False(id.Insertable, "Id (identity) must not be Insertable.");
+        Assert.False(id.Updatable, "Id (identity) must not be Updatable.");
+
+        // Regular table columns — must be both insertable and updatable.
+        foreach (var (name, f) in new[] {
+            (nameof(Fld.Code), (Field)Fld.Code),
+            (nameof(Fld.Amount), (Field)Fld.Amount),
+            (nameof(Fld.Status), (Field)Fld.Status)})
         {
-            var insertable = (f.Flags & FieldFlags.Insertable) == FieldFlags.Insertable;
-            var updatable = (f.Flags & FieldFlags.Updatable) == FieldFlags.Updatable;
-            var notMapped = (f.Flags & FieldFlags.NotMapped) != 0;
-            var calculated = (f.Flags & FieldFlags.Calculated) != 0;
-            var foreign = (f.Flags & FieldFlags.Foreign) != 0;
-            Console.WriteLine(
-                $"{f.Name}: Flags={f.Flags} Insertable={insertable} Updatable={updatable} " +
-                $"NotMapped={notMapped} Calculated={calculated} Foreign={foreign}");
+            var r = Read(f);
+            Assert.True(r.Insertable, $"{name}: expected Insertable=true.");
+            Assert.True(r.Updatable, $"{name}: expected Updatable=true.");
+            Assert.False(r.NotMapped, $"{name}: expected NotMapped=false.");
+            Assert.False(r.Calculated, $"{name}: expected Calculated=false.");
+            Assert.False(r.Foreign, $"{name}: expected Foreign=false.");
         }
+
+        // [Expression]-decorated AmountDoubled — Serenity sets Foreign+Calculated.
+        // Note: in this row the attribute does NOT clear Insertable/Updatable
+        // automatically; that's the whole point of the expression-trap tests.
+        var ad = Read(Fld.AmountDoubled);
+        Assert.True(ad.Calculated, "AmountDoubled: expected Calculated=true (from [Expression]).");
+        Assert.True(ad.Foreign, "AmountDoubled: expected Foreign=true (from [Expression]).");
     }
 
     /// <summary>Read columns from the test table via raw ADO.NET — avoids any
@@ -298,5 +327,91 @@ public sealed class RepositoryWriteIntegrationTests : IDisposable
         var (code, amount, _) = ReadRow((int)newId);
         Assert.Equal("X-002", code);
         Assert.Equal(1m, amount);
+    }
+
+    /// <summary>
+    /// Symmetric trap on the UPDATE path: assigning an Expression field on a
+    /// row passed to UpdateAsync(row) puts it in the SET list and SQL Server
+    /// rejects the statement. Documents that the trap is not INSERT-only.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_AssignedExpressionField_FailsAtSqlBecauseExpressionIsNotARealColumn()
+    {
+        var seedId = await _repo.CreateAsync(new IntegrationTestRow
+        {
+            Code = "X-003",
+            Amount = 2m,
+            Status = "Initial",
+        });
+
+        var update = new IntegrationTestRow
+        {
+            Id = (int)seedId,
+            Status = "Updated",
+            AmountDoubled = 8888m,    // Expression — assigning puts it in SET
+        };
+
+        await Assert.ThrowsAsync<Microsoft.Data.SqlClient.SqlException>(() =>
+            _repo.UpdateAsync(update));
+    }
+
+    /// <summary>
+    /// And the cure on the UPDATE path:
+    /// <see cref="RepositoryBase{TRow, TKey}.UpdateExcludingAsync"/> drops
+    /// the assigned Expression field before building the SET list.
+    /// </summary>
+    [Fact]
+    public async Task UpdateExcludingAsync_DropsAssignedExpressionField()
+    {
+        var seedId = await _repo.CreateAsync(new IntegrationTestRow
+        {
+            Code = "X-004",
+            Amount = 3m,
+            Status = "Initial",
+        });
+
+        var update = new IntegrationTestRow
+        {
+            Id = (int)seedId,
+            Status = "Updated",
+            AmountDoubled = 7777m,    // assigned, but excluded below
+        };
+
+        var ok = await _repo.UpdateExcludingAsync(update, [Fld.AmountDoubled]);
+        Assert.True(ok);
+
+        var (code, amount, status) = ReadRow((int)seedId);
+        Assert.Equal("X-004", code);          // unchanged
+        Assert.Equal(3m, amount);             // unchanged
+        Assert.Equal("Updated", status);      // updated
+    }
+
+    /// <summary>
+    /// Validation guard on UpdateAsync(row, fields): cannot include the Id
+    /// column in the SET list. The Id belongs in WHERE.
+    /// </summary>
+    [Fact]
+    public async Task UpdateAsync_WithFieldsContainingIdField_ThrowsArgumentException()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _repo.UpdateAsync(
+                new IntegrationTestRow { Id = 1, Code = "x" },
+                [Fld.Id, Fld.Code]));
+        Assert.Contains("Id", ex.Message);
+    }
+
+    /// <summary>
+    /// Validation guard on CreateAsync(row, fields): cannot include
+    /// non-insertable fields (identity column, NotMapped, Expression with
+    /// Insertable=false, etc.).
+    /// </summary>
+    [Fact]
+    public async Task CreateAsync_WithFieldsContainingNonInsertable_ThrowsArgumentException()
+    {
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            _repo.CreateAsync(
+                new IntegrationTestRow { Code = "x" },
+                [Fld.Code, Fld.Id])); // Id is identity, not insertable
+        Assert.Contains("Id", ex.Message);
     }
 }

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs
@@ -1,0 +1,302 @@
+using Idevs.Repositories;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// End-to-end repository write tests against a real SQL Server (Testcontainers).
+/// Verifies that Serenity's auto-exclusion of NotMapped/Expression fields
+/// holds for the new helpers, and that the include/exclude overloads emit
+/// the expected column lists.
+/// </summary>
+[Collection(nameof(MsSqlContainerCollection))]
+[Trait("Category", "Integration")]
+public sealed class RepositoryWriteIntegrationTests : IDisposable
+{
+    private readonly MsSqlContainerFixture _fixture;
+    private readonly TestRepository _repo;
+
+    private sealed class TestRepository(ISqlConnections sqlConnections)
+        : RepositoryBase<IntegrationTestRow, int>(sqlConnections);
+
+    public RepositoryWriteIntegrationTests(MsSqlContainerFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.TruncateTestTable();
+        _repo = new TestRepository(fixture.SqlConnections);
+    }
+
+    public void Dispose() => _fixture.TruncateTestTable();
+
+    private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
+
+    [Fact]
+    public void Diagnose_FieldFlags()
+    {
+        foreach (var f in IntegrationTestRow.Fields)
+        {
+            var insertable = (f.Flags & FieldFlags.Insertable) == FieldFlags.Insertable;
+            var updatable = (f.Flags & FieldFlags.Updatable) == FieldFlags.Updatable;
+            var notMapped = (f.Flags & FieldFlags.NotMapped) != 0;
+            var calculated = (f.Flags & FieldFlags.Calculated) != 0;
+            var foreign = (f.Flags & FieldFlags.Foreign) != 0;
+            Console.WriteLine(
+                $"{f.Name}: Flags={f.Flags} Insertable={insertable} Updatable={updatable} " +
+                $"NotMapped={notMapped} Calculated={calculated} Foreign={foreign}");
+        }
+    }
+
+    /// <summary>Read columns from the test table via raw ADO.NET — avoids any
+    /// Serenity row materialization in the assertions, so the test verifies
+    /// what's actually persisted, independent of how it would be re-read.</summary>
+    private (string? Code, decimal? Amount, string? Status) ReadRow(int id)
+    {
+        using var conn = _fixture.SqlConnections.NewByKey("Default");
+        conn.EnsureOpen();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Code, Amount, Status FROM dbo.IntegrationTestRows WHERE Id = @id";
+        var p = cmd.CreateParameter();
+        p.ParameterName = "@id";
+        p.Value = id;
+        cmd.Parameters.Add(p);
+        using var reader = cmd.ExecuteReader();
+        Assert.True(reader.Read(), $"Row with Id={id} not found.");
+        var code = reader.IsDBNull(0) ? null : reader.GetString(0);
+        var amount = reader.IsDBNull(1) ? (decimal?)null : reader.GetDecimal(1);
+        var status = reader.IsDBNull(2) ? null : reader.GetString(2);
+        return (code, amount, status);
+    }
+
+    // ---- Default CreateAsync(row) ----
+
+    [Fact]
+    public async Task CreateAsync_RowWithNotMappedFieldAssigned_InsertsOnlyTableColumns()
+    {
+        // NotMapped property is set (in CLR memory) but Serenity sees no
+        // backing Field for it, so the value cannot reach SQL. Expression
+        // fields would also reach SQL if you ASSIGN them — so we leave
+        // AmountDoubled alone (the production-correct pattern: Expression
+        // fields are read-only outputs, not inputs).
+        var row = new IntegrationTestRow
+        {
+            Code = "C-001",
+            Amount = 100.50m,
+            Status = "Pending",
+            TransientNote = "this should NOT be persisted",  // [NotMapped]
+        };
+
+        var newId = await _repo.CreateAsync(row);
+
+        Assert.True(newId > 0);
+
+        // Re-read via direct SQL to confirm the persisted row.
+        var (code, amount, status) = ReadRow((int)newId);
+        Assert.Equal("C-001", code);
+        Assert.Equal(100.50m, amount);
+        Assert.Equal("Pending", status);
+    }
+
+    // ---- Default UpdateAsync(row) ----
+
+    [Fact]
+    public async Task UpdateAsync_RowWithNotMappedAssigned_UpdatesOnlyTableColumns()
+    {
+        // Insert baseline row.
+        var seedId = await _repo.CreateAsync(new IntegrationTestRow
+        {
+            Code = "U-001",
+            Amount = 10m,
+            Status = "Initial",
+        });
+
+        // Mutate including a write to the NotMapped property — Serenity has
+        // no Field for it so it cannot be in the UPDATE.
+        var update = new IntegrationTestRow
+        {
+            Id = (int)seedId,
+            Status = "Updated",
+            TransientNote = "should not persist",
+        };
+
+        var ok = await _repo.UpdateAsync(update);
+        Assert.True(ok);
+
+        var (code, amount, status) = ReadRow((int)seedId);
+        Assert.Equal("U-001", code);          // Code untouched
+        Assert.Equal(10m, amount);            // Amount untouched
+        Assert.Equal("Updated", status);      // Status updated
+    }
+
+    // ---- Include-only CreateAsync(row, fields) ----
+
+    [Fact]
+    public async Task CreateAsync_WithExplicitFields_InsertsOnlyListedColumns()
+    {
+        var row = new IntegrationTestRow
+        {
+            Code = "I-001",
+            Amount = 999m,                       // assigned but NOT in include list
+            Status = "Hidden",                   // assigned but NOT in include list
+        };
+
+        var newId = await _repo.CreateAsync(row, [Fld.Code, Fld.Amount]);
+        Assert.True(newId > 0);
+
+        var (code, amount, status) = ReadRow((int)newId);
+        Assert.Equal("I-001", code);
+        Assert.Equal(999m, amount);
+        Assert.Null(status);   // not in include list — DB default (null) wins
+    }
+
+    // ---- Include-only UpdateAsync(row, fields) ----
+
+    [Fact]
+    public async Task UpdateAsync_WithExplicitFields_UpdatesOnlyListedColumns()
+    {
+        var seedId = await _repo.CreateAsync(new IntegrationTestRow
+        {
+            Code = "I-002",
+            Amount = 50m,
+            Status = "Initial",
+        });
+
+        var update = new IntegrationTestRow
+        {
+            Id = (int)seedId,
+            Code = "WRONG-CODE",
+            Amount = 75m,
+            Status = "ShouldBePreserved",
+        };
+
+        // Only Amount is in the include list, so Code and Status must NOT change.
+        var ok = await _repo.UpdateAsync(update, [Fld.Amount]);
+        Assert.True(ok);
+
+        var (code, amount, status) = ReadRow((int)seedId);
+        Assert.Equal("I-002", code);          // unchanged
+        Assert.Equal(75m, amount);            // updated
+        Assert.Equal("Initial", status);      // unchanged
+    }
+
+    // ---- Exclude CreateExcludingAsync(row, excludeFields) ----
+
+    [Fact]
+    public async Task CreateExcludingAsync_OmitsListedFields_AndStillSkipsNotMapped()
+    {
+        var row = new IntegrationTestRow
+        {
+            Code = "E-001",
+            Amount = 200m,
+            Status = "WillBeOmitted",
+            TransientNote = "still ignored",  // [NotMapped] — never reaches SQL
+        };
+
+        // Exclude Status explicitly; Code and Amount should be inserted.
+        var newId = await _repo.CreateExcludingAsync(row, [Fld.Status]);
+        Assert.True(newId > 0);
+
+        var (code, amount, status) = ReadRow((int)newId);
+        Assert.Equal("E-001", code);
+        Assert.Equal(200m, amount);
+        Assert.Null(status);
+    }
+
+    // ---- Exclude UpdateExcludingAsync(row, excludeFields) ----
+
+    [Fact]
+    public async Task UpdateExcludingAsync_OmitsListedFields_AndStillSkipsNotMapped()
+    {
+        var seedId = await _repo.CreateAsync(new IntegrationTestRow
+        {
+            Code = "E-002",
+            Amount = 1m,
+            Status = "PreservedStatus",
+        });
+
+        var update = new IntegrationTestRow
+        {
+            Id = (int)seedId,
+            Code = "WRONG-CODE",                  // assigned, but excluded below
+            Amount = 5m,                          // should update
+            Status = "WRONG-STATUS",              // assigned, but excluded below
+            TransientNote = "ignored",            // [NotMapped] — never reaches SQL
+        };
+
+        var ok = await _repo.UpdateExcludingAsync(update, [Fld.Code, Fld.Status]);
+        Assert.True(ok);
+
+        var (code, amount, status) = ReadRow((int)seedId);
+        Assert.Equal("E-002", code);                // excluded — preserved
+        Assert.Equal(5m, amount);                   // updated
+        Assert.Equal("PreservedStatus", status);    // excluded — preserved
+    }
+
+    // ---- Argument guards ----
+
+    [Fact]
+    public async Task CreateAsync_NullFields_Throws()
+        => await Assert.ThrowsAsync<ArgumentNullException>(() =>
+               _repo.CreateAsync(new IntegrationTestRow { Code = "x" }, fields: null!));
+
+    [Fact]
+    public async Task CreateAsync_EmptyFields_Throws()
+        => await Assert.ThrowsAsync<ArgumentException>(() =>
+               _repo.CreateAsync(new IntegrationTestRow { Code = "x" }, fields: []));
+
+    [Fact]
+    public async Task UpdateAsync_WithFieldsButMissingId_Throws()
+        => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+               _repo.UpdateAsync(new IntegrationTestRow { Code = "x" }, [Fld.Code]));
+
+    [Fact]
+    public async Task UpdateExcludingAsync_MissingId_Throws()
+        => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+               _repo.UpdateExcludingAsync(new IntegrationTestRow { Code = "x" }, [Fld.Status]));
+
+    /// <summary>
+    /// Documents Serenity's actual behavior: an Expression-decorated field
+    /// CAN end up in the INSERT/UPDATE if its value is "assigned" on the row.
+    /// This is per Serenity's IsAssigned-based filter — Expression fields are
+    /// auto-skipped when un-assigned (the production-correct case: they're
+    /// read-only outputs of a SELECT projection), but become writable when
+    /// you set them. The fix is either: (1) don't assign them, (2) use
+    /// CreateExcludingAsync / UpdateExcludingAsync to opt them out, or
+    /// (3) use the include-only CreateAsync(row, fields) overload to control
+    /// the column list explicitly.
+    /// </summary>
+    [Fact]
+    public async Task CreateAsync_AssignedExpressionField_FailsAtSqlBecauseExpressionIsNotARealColumn()
+    {
+        var row = new IntegrationTestRow
+        {
+            Code = "X-001",
+            Amount = 1m,
+            AmountDoubled = 9999m,   // Expression field — assigning it puts it in INSERT
+        };
+
+        await Assert.ThrowsAsync<Microsoft.Data.SqlClient.SqlException>(() =>
+            _repo.CreateAsync(row));
+    }
+
+    /// <summary>
+    /// And the cure: <see cref="RepositoryBase{TRow}.CreateExcludingAsync"/>
+    /// lets the caller drop the Expression field even when it was assigned.
+    /// </summary>
+    [Fact]
+    public async Task CreateExcludingAsync_DropsAssignedExpressionField()
+    {
+        var row = new IntegrationTestRow
+        {
+            Code = "X-002",
+            Amount = 1m,
+            AmountDoubled = 9999m,   // assigned, but excluded below
+        };
+
+        var newId = await _repo.CreateExcludingAsync(row, [Fld.AmountDoubled]);
+        Assert.True(newId > 0);
+
+        var (code, amount, _) = ReadRow((int)newId);
+        Assert.Equal("X-002", code);
+        Assert.Equal(1m, amount);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the gap PowerACC hit around `[NotMapped]` and `[Expression]` field handling on writes, plus adds explicit-fields helpers for surgical column control. Verified end-to-end against a real SQL Server 2022 container via Testcontainers.

## API additions

| Helper | On | Behavior |
|---|---|---|
| `CreateAsync(TRow row, Field[] fields, ...)` | `RepositoryBase<TRow>` | INSERT only listed columns; bypasses IsAssigned tracking. |
| `CreateExcludingAsync(TRow row, Field[] excludeFields, ...)` | `RepositoryBase<TRow>` | INSERT all assigned, table-mapped fields EXCEPT listed. |
| `UpdateAsync(TRow row, Field[] fields, ...)` | `RepositoryBase<TRow, TKey>` | UPDATE only listed columns by Id. |
| `UpdateExcludingAsync(TRow row, Field[] excludeFields, ...)` | `RepositoryBase<TRow, TKey>` | UPDATE all assigned, table-mapped fields EXCEPT listed. |

Plus sync `[Obsolete]` wrappers for each (`Create`, `CreateExcluding`, `Update`, `UpdateExcluding`).

## What integration tests revealed (and now document)

- **`[NotMapped]` properties** — production-correct pattern is a plain CLR auto-property with **no** backing `Field` in `RowFields`. Setting it is silent (no SQL representation). If you DO declare a Field, `[NotMapped]` alone won't clear default `Insertable`/`Updatable` flags — pair with `[SetFieldFlags(...)]`.
- **`[Expression]` fields** — these ARE meant for SELECT-time materialization. But Serenity's `InsertAndGetID` / `UpdateById` use an IsAssigned-based filter, so **assigning** an Expression field on a write path puts it in the SQL → SQL Server rejects with "Invalid column name". The cure: don't assign them, or use the new exclude/include helpers.

Both trap and cure are demonstrated by negative + positive tests in `RepositoryWriteIntegrationTests`.

## Test infrastructure

- New `Testcontainers.MsSql` package (centralized via `Directory.Packages.props`).
- `MsSqlContainerFixture` — `IAsyncLifetime` xUnit collection fixture that starts SQL Server 2022, registers the `Microsoft.Data.SqlClient` provider with `DbProviderFactories`, and creates the test schema.
- All integration tests tagged `[Trait("Category", "Integration")]`. Skip locally with `dotnet test --filter "Category!=Integration"` if Docker isn't available. CI on GitHub-hosted Linux runners has Docker built-in.

## Files

- `src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs` — added 2 async + 2 sync wrappers
- `src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs` — added 2 async + 2 sync wrappers
- `src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt` — 8 new entries
- `tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs` — new
- `tests/Idevs.Net.CoreLib.Tests/Integration/IntegrationTestRow.cs` — new
- `tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs` — new (13 tests)
- `Directory.Packages.props` + test csproj — added `Testcontainers.MsSql`
- `CHANGELOG.md` + `MIGRATION.md` — 0.7.4 sections
- 4 csproj — bumped to `0.7.4`

## Test plan

- [x] Build green (.NET 8 + .NET 10).
- [x] Unit tests pass (108).
- [x] Integration tests pass against SQL Server 2022 container (13).
- [x] Total 121 / 121.
- [ ] CI `Build & Test` passes (needs Docker on the runner — GitHub-hosted Linux has it).
- [ ] Copilot auto-review.
- [ ] After merge, `release.yml` publishes 0.7.4 nupkgs + `v0.7.4` GitHub Release.