### PR TITLE
feat: add row-lock primitives + InNewTransactionAsync (0.7.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,88 @@
 # Changelog
 
+## 0.7.6 (2026-05-07)
+
+### Added
+
+- `LockMode` enum with four members: `Update` (FOR UPDATE / UPDLOCK +
+  HOLDLOCK + ROWLOCK), `Share` (FOR SHARE / HOLDLOCK), `UpdateNoWait`
+  (FOR UPDATE NOWAIT — Postgres / MySQL 8+ / MariaDB 10.6+ / Oracle only;
+  SqlServer throws), and `UpdateSkip` (FOR UPDATE SKIP LOCKED / READPAST
+  on SqlServer — queue-consumer pattern).
+- `SqlQuery.ForUpdate(mode = LockMode.Update)` fluent extension that
+  flags a SELECT for row-level locking. The dialect-correct clause is
+  applied at execution time when the query is materialised through
+  Idevs repository helpers (`RepositoryBase<TRow>.TryFirstAsync` today;
+  more in 0.8.0). Direct Serenity execution paths
+  (`connection.TryFirst<TRow>(query)`) DO NOT honour the flag and
+  silently produce non-locking SQL — always go through Idevs helpers
+  when locking matters.
+- `SqlServiceBase.InNewTransactionAsync<T>(work, ct)` and the void
+  overload — explicit "fresh transaction" helper for short-lived
+  operations that must commit (or fail) independently of any ambient
+  `IUnitOfWork`. Use for sequence/document-number allocation, audit
+  log writes, and idempotency-key reservation. Replaces the implicit
+  `CommitOnSuccessAsync(work, uow: null, ct)` trick with a
+  self-documenting name.
+
+### Changed
+
+- `RepositoryBase<TRow>.TryFirstAsync` now detects the `ForUpdate()`
+  flag at execution time. When set, it materialises the SELECT itself,
+  injects the dialect-correct lock hint via the internal
+  `RowLockSqlBuilder`, executes through `SqlHelper.ExecuteReader`
+  (which honours Serenity's `WrappedConnection` transaction
+  propagation), and maps the result row via `SqlQuery.GetFromReader`.
+  Behaviour is unchanged for queries that don't call `ForUpdate()` —
+  the existing Serenity `TryFirst<TRow>` lambda path is preserved.
+- `TryFirstAsync` with a flagged query MUST be called inside an
+  active transaction. Calling it without a non-null `uow` throws
+  `InvalidOperationException` — taking a row lock outside a
+  transaction is meaningless on every supported engine.
+
+### Verified (xUnit + Testcontainers)
+
+- 27 unit tests cover `RowLockSqlBuilder` across SqlServer, MySQL/MariaDB,
+  Postgres, Oracle (ANSI fallback), and SQLite (always throws), plus
+  argument-validation edges.
+- 6 SqlServer integration tests (5 passing + 1 documented skip) verify:
+  `ForUpdate` without a transaction throws; inside a transaction
+  acquires the row lock and returns the row; a second locker blocks
+  until the first commits; `UpdateNoWait` throws as documented; and
+  the standard non-locking path is untouched.
+- `ConcurrentSequenceAllocationTests` pins the actual race fix that
+  motivated the work: 50 parallel allocators against the same
+  sequence row produce 50 distinct values.
+- `InNewTransactionAsyncTests` pins the independent-commit semantic:
+  inner writes survive an outer rollback; inner exceptions roll back
+  only the inner write.
+
+### Notes / known limitations
+
+- **`LockMode.UpdateNoWait` on SqlServer**: SqlServer has no in-query
+  NOWAIT hint. The library throws `NotSupportedException` rather than
+  emit incorrect SQL. Workaround: `SET LOCK_TIMEOUT 0` at the session
+  or transaction level before the locking SELECT, then catch SQL
+  error 1222 (lock-request timeout).
+- **`LockMode.UpdateSkip` on SqlServer**: emits
+  `WITH (UPDLOCK, HOLDLOCK, ROWLOCK, READPAST)`. READPAST requires
+  the active transaction to be in `READ COMMITTED` or `REPEATABLE READ`
+  isolation. The default isolation in some SqlServer container
+  configurations is incompatible — verify your transaction's isolation
+  before relying on `UpdateSkip` against SqlServer. Postgres and
+  MySQL don't have this caveat.
+- **SQLite**: row-level locking is not supported; every `LockMode`
+  throws `NotSupportedException`. Use `BEGIN IMMEDIATE` for a
+  database-wide write lock instead.
+- **Independent-commit trade-off in `InNewTransactionAsync`**: work
+  committed inside the helper does NOT roll back if the caller's outer
+  business transaction subsequently fails. This is intentional —
+  document-number allocations have to survive outer rollback (gaps in
+  the sequence are normal, duplicate numbers are catastrophic). For
+  anything where the inner write must roll back with the outer flow,
+  do NOT use `InNewTransactionAsync`; pass the caller's UoW through
+  and let the outer transaction own the commit.
+
 ## 0.7.5 (2026-05-04)
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 
 ## Contents
 
+- [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](#v075--v076--row-lock-primitives--innewtransactionasync)
 - [v0.7.4 → v0.7.5 — CountAsync + ExistsAsync helpers](#v074--v075--countasync--existsasync-helpers)
 - [v0.7.3 → v0.7.4 — Explicit-fields Create/Update + NotMapped/Expression handling](#v073--v074--explicit-fields-createupdate--notmappedexpression-handling)
 - [v0.7.2 → v0.7.3 — Unit of Work Helpers (BeginUnitOfWork + CommitOnSuccessAsync)](#v072--v073--unit-of-work-helpers-beginunitofwork--commitonsuccessasync)
@@ -13,6 +14,160 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 - [v0.3.x → v0.5.0 — Package Layout & DI Changes](#v03x--v050--package-layout--di-changes)
 - [v0.1.x → v0.2.0 — Autofac Integration](#v01x--v020--autofac-integration)
 - [v0.0.x → v0.1.x — Service Registration & Chrome Setup](#v00x--v01x--service-registration--chrome-setup)
+
+---
+
+## v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync
+
+### What changed
+
+Two new primitives that together unblock the classic SELECT-then-UPDATE
+race in caller code (e.g. `DocumentNumberRepository.GetNextDocNoAsync`):
+
+| Primitive | Where | What it does |
+|---|---|---|
+| `SqlQuery.ForUpdate(LockMode mode = Update)` | extension method | Marks the query for row-level locking. Hint applied dialect-correctly when materialised through Idevs repository helpers. |
+| `SqlServiceBase.InNewTransactionAsync<T>` | `protected` on `SqlServiceBase` | Runs work in a fresh connection + transaction, ignoring any ambient `IUnitOfWork`. Commits on success, rolls back on throw. |
+
+Plus a `LockMode` enum (`Update` / `Share` / `UpdateNoWait` / `UpdateSkip`)
+and behavioural changes to `RepositoryBase<TRow>.TryFirstAsync` (it now
+detects the `ForUpdate()` flag at execution time).
+
+### Why
+
+Before 0.7.6, locking a row for read-then-write required either dropping
+to raw Dapper or accepting that the lock window covers the entire
+caller's transaction. Both are footguns:
+
+```csharp
+// Before — race condition. Two concurrent callers can both read 41 and
+// both write 42, producing duplicate document numbers.
+public Task<long> GetNextDocNoAsync(IUnitOfWork uow, ...)
+{
+    var doc = await TryFirstAsync(q => q.SelectTableFields().Where(...), uow, ct);
+    doc.NextDocumentNo += 1;
+    await UpdateAsync(doc, uow, ct);
+    return doc.NextDocumentNo.Value;
+}
+```
+
+After 0.7.6:
+
+```csharp
+public Task<long> GetNextDocNoAsync(IUnitOfWork? uow, ...)
+{
+    // InNewTransactionAsync deliberately ignores the caller's uow so the
+    // lock window stays small. The number is allocated even if the
+    // outer business transaction subsequently rolls back — gaps are OK,
+    // duplicates are catastrophic.
+    return InNewTransactionAsync(async (innerUow, token) =>
+    {
+        var doc = await TryFirstAsync(
+            q => q.SelectTableFields()
+                  .Where(...)
+                  .ForUpdate(),                  // <-- new
+            innerUow, token);
+
+        doc.NextDocumentNo += 1;
+        await UpdateAsync(doc, innerUow, token);
+        return doc.NextDocumentNo.Value;
+    }, ct);
+}
+```
+
+### `LockMode` reference
+
+| Mode | SqlServer | MySQL / MariaDB | Postgres | Oracle | SQLite |
+|---|---|---|---|---|---|
+| `Update` | `WITH (UPDLOCK, HOLDLOCK, ROWLOCK)` | `FOR UPDATE` | `FOR UPDATE` | `FOR UPDATE` | throws |
+| `Share` | `WITH (HOLDLOCK, ROWLOCK)` | `LOCK IN SHARE MODE` | `FOR SHARE` | not portable; throws | throws |
+| `UpdateNoWait` | **throws** (no in-query NOWAIT) | `FOR UPDATE NOWAIT` (8.0+ / 10.6+) | `FOR UPDATE NOWAIT` | `FOR UPDATE NOWAIT` | throws |
+| `UpdateSkip` | `WITH (UPDLOCK, HOLDLOCK, ROWLOCK, READPAST)` | `FOR UPDATE SKIP LOCKED` (8.0+ / 10.6+) | `FOR UPDATE SKIP LOCKED` (9.5+) | `FOR UPDATE SKIP LOCKED` | throws |
+
+### `InNewTransactionAsync` semantics — read this before using
+
+The helper opens a **separate** connection and transaction. It commits on
+success and rolls back on exception, **regardless of any ambient**
+`IUnitOfWork` the caller has open.
+
+The trade-off is intentional: if the outer caller throws after this
+helper returns, the work committed inside the helper **remains**. For
+sequence allocation that's the correct behaviour — gaps are normal,
+duplicates are catastrophic. For anything where the inner write must
+roll back with the outer flow, do NOT use `InNewTransactionAsync`: pass
+the caller's UoW through and let the outer transaction own the commit.
+
+### Migrating existing call sites
+
+If you currently:
+
+| Pattern | Migration |
+|---|---|
+| Drop to raw Dapper for `SELECT … FOR UPDATE` | Use `q.ForUpdate()` on the existing `SqlQuery` builder. |
+| Use `CommitOnSuccessAsync(work, uow: null, ct)` to bypass an ambient UoW | Use `InNewTransactionAsync(work, ct)` — same behaviour, self-documenting name. |
+| Hand-roll connection + `BeginTransaction()` for sequence allocators | Use `InNewTransactionAsync` and put `q.ForUpdate()` on the SELECT inside the body. |
+
+The original `CommitOnSuccessAsync` overload is unchanged — keep using
+it for the case where you want to "join the caller's UoW or open a fresh
+one" (the default behaviour). `InNewTransactionAsync` is the new helper
+for the explicitly-fresh case.
+
+### Behavioural change to `TryFirstAsync`
+
+Queries that don't call `ForUpdate()` execute exactly as before — through
+Serenity's `connection.TryFirst<TRow>(q => …)` lambda path. Queries that
+DO call `ForUpdate()` take a different code path:
+
+1. The SELECT is materialised via `query.ToString()`.
+2. The dialect-correct lock hint is injected via the internal
+   `RowLockSqlBuilder`.
+3. Execution goes through `SqlHelper.ExecuteReader(connection, sql, params, logger)`
+   so transaction propagation through Serenity's `WrappedConnection`
+   is preserved.
+4. Row mapping uses `SqlQuery.GetFromReader(reader)` — the same
+   primitive Serenity's lambda path uses internally.
+
+The lock-aware path requires a non-null `uow`. Calling
+`TryFirstAsync(q => q.…ForUpdate(), uow: null)` throws
+`InvalidOperationException`.
+
+### Important caveats
+
+- **Direct Serenity execution paths do NOT honour `ForUpdate()`.** If
+  you write `connection.TryFirst<TRow>(q => q.…ForUpdate())`,
+  `connection.Query<TRow>(q => q.…ForUpdate())`, or any other Serenity
+  extension method that takes a `SqlQuery`, the flag is silently
+  ignored and the SELECT runs without a lock. Always call through
+  Idevs repository helpers when locking matters.
+- **`UpdateNoWait` is unsupported on SqlServer.** SqlServer has no
+  in-query NOWAIT hint. The library throws. Workaround:
+  `SET LOCK_TIMEOUT 0` at the session/transaction level before the
+  locking SELECT, then catch SQL error 1222.
+- **`UpdateSkip` requires READ COMMITTED or REPEATABLE READ on
+  SqlServer.** READPAST is rejected at higher isolation levels with
+  error 16957. Verify the active transaction's isolation level before
+  relying on `UpdateSkip` against SqlServer.
+- **Connection pool sizing.** `InNewTransactionAsync` opens a second
+  connection during the call. Verify peak concurrency × 2 ≤ your
+  configured `Max Pool Size`.
+- **No identity-return path for bulk operations.** If you need the
+  identity values from a multi-row operation, do not bulk-merge
+  through this helper.
+
+### Verifying production data
+
+If you suspect a race condition has fired silently before adopting this
+fix, run a duplicate check against your sequence-counter tables:
+
+```sql
+SELECT DocumentCode, NextDocumentNo, COUNT(*)
+FROM DocumentNumber
+GROUP BY DocumentCode, NextDocumentNo
+HAVING COUNT(*) > 1;
+```
+
+Any results indicate the race has produced duplicates that need
+backfilling before deployment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,34 @@ Three layered base classes for data access:
 
 Connection key is configurable via the virtual `ConnectionKey` property or the `[ConnectionKey("Warehouse")]` attribute (resolved on the derived class).
 
+#### Concurrency primitives (0.7.6)
+
+For SELECT-then-UPDATE patterns that must stay atomic across concurrent callers — sequence allocation, balance transfers, queue consumers — two new primitives:
+
+| Primitive | Where | What it does |
+|---|---|---|
+| `SqlQuery.ForUpdate(LockMode mode = Update)` | extension | Marks the query for row-level locking. Hint applied dialect-correctly when the query is materialised through Idevs repository helpers (`UPDLOCK/HOLDLOCK` on SqlServer, `FOR UPDATE` on MySQL/Postgres/Oracle). SQLite throws. Direct Serenity execution paths silently ignore the flag — go through Idevs helpers when locking matters. |
+| `SqlServiceBase.InNewTransactionAsync<T>(work, ct)` | `protected` | Runs `work` in a fresh connection and transaction, ignoring any ambient `IUnitOfWork`. Commits on success, rolls back on throw. Independent commit semantics: inner writes survive an outer rollback. |
+
+`LockMode` has four members: `Update` (default), `Share`, `UpdateNoWait`, `UpdateSkip`. See [MIGRATION.md](MIGRATION.md#v075--v076--row-lock-primitives--innewtransactionasync) for the full dialect matrix and engine-specific caveats (SqlServer has no in-query NOWAIT; SqlServer `UpdateSkip` requires READ COMMITTED isolation).
+
+```csharp
+// Atomic sequence allocation: SELECT ... FOR UPDATE inside a fresh
+// transaction, regardless of the caller's outer UoW. Allocated number
+// survives even if the caller's outer business transaction rolls back —
+// gaps are normal, duplicates are catastrophic.
+public Task<long> AllocateNextDocNoAsync(string code, CancellationToken ct = default) =>
+    InNewTransactionAsync(async (uow, token) =>
+    {
+        var row = await TryFirstAsync(
+            q => q.SelectTableFields().Where(Fld.DocCode == code).ForUpdate(),
+            uow, token);
+        row.NextDocNo += 1;
+        await UpdateAsync(row, uow, token);
+        return row.NextDocNo.Value;
+    }, ct);
+```
+
 #### Example
 
 ```csharp
@@ -619,6 +647,10 @@ If the generator misbehaves on a specific build, set `<IdevsCoreLibUseSourceGene
 
 Detailed upgrade notes for every minor and major version live in [MIGRATION.md](MIGRATION.md). Latest transitions:
 
+- [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](MIGRATION.md#v075--v076--row-lock-primitives--innewtransactionasync)
+- [v0.7.4 → v0.7.5 — CountAsync + ExistsAsync helpers](MIGRATION.md#v074--v075--countasync--existsasync-helpers)
+- [v0.7.3 → v0.7.4 — Explicit-fields Create/Update + NotMapped/Expression handling](MIGRATION.md#v073--v074--explicit-fields-createupdate--notmappedexpression-handling)
+- [v0.7.2 → v0.7.3 — Unit of Work Helpers (BeginUnitOfWork + CommitOnSuccessAsync)](MIGRATION.md#v072--v073--unit-of-work-helpers-beginunitofwork--commitonsuccessasync)
 - [v0.7.1 → v0.7.2 — RepositoryBase Criteria-Based Update/Delete + TryFirst Alias](MIGRATION.md#v071--v072--repositorybase-criteria-based-updatedelete--tryfirst-alias)
 - [v0.6.x → v0.7.0 — Source-Generator DI Registration](MIGRATION.md#v06x--v070--source-generator-di-registration)
 - [v0.5.0 → v0.6.0 — RepositoryBase Redesign](MIGRATION.md#v050--v060--repositorybase-redesign)

--- a/src/Idevs.Net.CoreLib/Repositories/LockMode.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/LockMode.cs
@@ -1,0 +1,43 @@
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Row-level lock intent applied via <see cref="SqlQueryLockExtensions.ForUpdate"/>.
+/// The hint is materialised by <see cref="RowLockSqlBuilder"/> using
+/// dialect-correct syntax for SqlServer, MySQL/MariaDB, PostgreSQL, and Oracle.
+/// SQLite has no row-level locking and throws on every mode.
+/// </summary>
+public enum LockMode
+{
+    /// <summary>
+    /// Exclusive update lock; blocks readers and writers.
+    /// SqlServer: <c>WITH (UPDLOCK, HOLDLOCK, ROWLOCK)</c>.
+    /// MySQL/MariaDB/PostgreSQL/Oracle: <c>FOR UPDATE</c>.
+    /// </summary>
+    Update,
+
+    /// <summary>
+    /// Shared (read) lock; blocks writers, allows other shared readers.
+    /// SqlServer: <c>WITH (HOLDLOCK, ROWLOCK)</c>.
+    /// PostgreSQL: <c>FOR SHARE</c>.
+    /// MySQL/MariaDB: <c>LOCK IN SHARE MODE</c>.
+    /// </summary>
+    Share,
+
+    /// <summary>
+    /// Exclusive update lock; throw immediately if any matched row is currently locked.
+    /// PostgreSQL / MySQL 8+ / MariaDB 10.6+ / Oracle: <c>FOR UPDATE NOWAIT</c>.
+    /// SqlServer: NOT SUPPORTED — there is no in-query NOWAIT hint. Use
+    /// <c>SET LOCK_TIMEOUT 0</c> at the session level and catch error 1222.
+    /// SQLite: not supported.
+    /// </summary>
+    UpdateNoWait,
+
+    /// <summary>
+    /// Exclusive update lock; skip rows currently locked by other transactions
+    /// (queue-consumer pattern).
+    /// SqlServer: <c>WITH (UPDLOCK, HOLDLOCK, ROWLOCK, READPAST)</c>.
+    /// PostgreSQL 9.5+ / MySQL 8+ / MariaDB 10.6+ / Oracle: <c>FOR UPDATE SKIP LOCKED</c>.
+    /// SQLite: not supported.
+    /// </summary>
+    UpdateSkip,
+}

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBase.cs
@@ -16,6 +16,15 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
     /// The query is pre-bound to <see cref="SqlServiceBase.Dialect"/> before
     /// <paramref name="configure"/> is invoked, so consumers don't need to call
     /// <c>q.Dialect(...)</c> themselves. Wraps Serenity's <c>Connection.TryFirst</c>.
+    /// <para>
+    /// When the configured query is flagged via
+    /// <see cref="SqlQueryLockExtensions.ForUpdate"/>, the SELECT is
+    /// materialised manually so the dialect-correct lock hint
+    /// (UPDLOCK/HOLDLOCK on SqlServer, FOR UPDATE on MySQL/Postgres) can be
+    /// injected. The locking path requires a non-null <paramref name="uow"/>
+    /// — taking a row lock outside a transaction is meaningless on every
+    /// supported engine.
+    /// </para>
     /// </remarks>
     public virtual Task<TRow?> TryFirstAsync(
         Action<SqlQuery> configure,
@@ -25,11 +34,45 @@ public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBa
         ArgumentNullException.ThrowIfNull(configure);
 
         return ExecuteAsync<TRow?>((c, _) =>
-            Task.FromResult<TRow?>(c.TryFirst<TRow>(q =>
+        {
+            // Bind a fresh row to the query up front so SelectTableFields()
+            // / WhereEqual(field,…) inside `configure` resolve against it. The
+            // same row is what GetFromReader populates after execution.
+            var row = new TRow();
+            var query = SqlQuery().From(row);
+            configure(query);
+
+            var lockMode = query.TryGetLockMode();
+            if (lockMode is null)
             {
-                q.Dialect(Dialect);
-                configure(q);
-            })), uow, ct);
+                // No lock — let Serenity's lambda-driven path handle execution
+                // and row mapping. configure runs again on its internal query;
+                // the call is idempotent so cost is negligible.
+                return Task.FromResult<TRow?>(c.TryFirst<TRow>(q =>
+                {
+                    q.Dialect(Dialect);
+                    configure(q);
+                }));
+            }
+
+            if (uow is null)
+                throw new InvalidOperationException(
+                    "ForUpdate() requires an active transaction. Pass a non-null uow, " +
+                    "or call inside InNewTransactionAsync.");
+
+            // Materialise SQL ourselves so we can inject the dialect-correct
+            // lock hint, then execute via SqlHelper which honours the active
+            // transaction on Serenity's WrappedConnection. Map the bound row
+            // using SqlQuery.GetFromReader.
+            var sql = RowLockSqlBuilder.Apply(query.ToString(), Dialect, lockMode.Value);
+
+            using var reader = SqlHelper.ExecuteReader(c, sql, query.Params, logger: null);
+            if (!reader.Read())
+                return Task.FromResult<TRow?>(null);
+
+            query.GetFromReader(reader);
+            return Task.FromResult<TRow?>(row);
+        }, uow, ct);
     }
 
     /// <summary>Return all rows that match the configured query.</summary>

--- a/src/Idevs.Net.CoreLib/Repositories/RowLockSqlBuilder.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowLockSqlBuilder.cs
@@ -1,0 +1,137 @@
+using System.Text.RegularExpressions;
+using Serenity.Data;
+
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Applies dialect-specific row-lock hints to a materialised SELECT statement.
+/// Internal — callers go through
+/// <see cref="SqlQueryLockExtensions.ForUpdate"/> on a query that is then
+/// materialised by <see cref="RepositoryBase{TRow}.TryFirstAsync"/> or a
+/// sibling helper.
+/// </summary>
+internal static class RowLockSqlBuilder
+{
+    /// <summary>
+    /// Insert (or append) a row-lock clause to <paramref name="sql"/> using
+    /// the syntax appropriate for <paramref name="dialect"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="sql"/> or <paramref name="dialect"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="mode"/> is not a defined enum value.</exception>
+    /// <exception cref="NotSupportedException">
+    /// SQLite (no row-level locking) on any mode; SqlServer on <see cref="LockMode.UpdateNoWait"/>;
+    /// non-SqlServer/MySQL/Postgres dialects on <see cref="LockMode.Share"/>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// SqlServer dialect but the SQL has no FROM clause — cannot inject a table hint.
+    /// </exception>
+    public static string Apply(string sql, ISqlDialect dialect, LockMode mode)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+        ArgumentNullException.ThrowIfNull(dialect);
+
+        var serverType = dialect.ServerType ?? string.Empty;
+
+        if (IsSqlServer(serverType))
+            return ApplySqlServer(sql, mode);
+        if (IsPostgres(serverType))
+            return sql + ApplyAnsi(mode, shareClause: " FOR SHARE", dialectName: serverType);
+        if (IsMySql(serverType))
+            return sql + ApplyAnsi(mode, shareClause: " LOCK IN SHARE MODE", dialectName: serverType);
+        if (IsSqlite(serverType))
+            throw new NotSupportedException(
+                "SQLite does not support row-level locking. Begin the transaction with " +
+                "BEGIN IMMEDIATE for a database-wide write lock instead.");
+
+        // Oracle and other ANSI-standard dialects accept FOR UPDATE [NOWAIT|SKIP LOCKED].
+        // Share mode is dialect-specific and not portable here.
+        return sql + ApplyAnsi(mode, shareClause: null, dialectName: serverType);
+    }
+
+    private static string ApplyAnsi(LockMode mode, string? shareClause, string dialectName) => mode switch
+    {
+        LockMode.Update => " FOR UPDATE",
+        LockMode.UpdateNoWait => " FOR UPDATE NOWAIT",
+        LockMode.UpdateSkip => " FOR UPDATE SKIP LOCKED",
+        LockMode.Share when shareClause is not null => shareClause,
+        LockMode.Share => throw new NotSupportedException(
+            $"FOR SHARE is not portable to dialect '{dialectName}'. Use Update mode."),
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown LockMode."),
+    };
+
+    private static string ApplySqlServer(string sql, LockMode mode)
+    {
+        var hint = mode switch
+        {
+            LockMode.Update => "WITH (UPDLOCK, HOLDLOCK, ROWLOCK)",
+            LockMode.Share => "WITH (HOLDLOCK, ROWLOCK)",
+            LockMode.UpdateSkip => "WITH (UPDLOCK, HOLDLOCK, ROWLOCK, READPAST)",
+            LockMode.UpdateNoWait => throw new NotSupportedException(
+                "SqlServer has no in-query NOWAIT hint. Set 'SET LOCK_TIMEOUT 0' " +
+                "at the session/transaction level before the SELECT, then catch " +
+                "error 1222 (lock-request timeout)."),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown LockMode."),
+        };
+        return InjectFirstTableHint(sql, hint);
+    }
+
+    private static bool IsSqlServer(string s) =>
+        s.Contains("SqlServer", StringComparison.OrdinalIgnoreCase) ||
+        s.Contains("MSSQL", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPostgres(string s) =>
+        s.Contains("Postgres", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsMySql(string s) =>
+        s.Contains("MySql", StringComparison.OrdinalIgnoreCase) ||
+        s.Contains("MariaDb", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSqlite(string s) =>
+        s.Contains("Sqlite", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Insert <paramref name="hint"/> immediately after the table reference in
+    /// the first FROM clause. Stops at the next major SQL keyword
+    /// (WHERE / JOIN / GROUP / ORDER / HAVING / UNION / EXCEPT / INTERSECT)
+    /// or end-of-statement.
+    /// </summary>
+    /// <remarks>
+    /// Works for the simple <c>SELECT … FROM &lt;table&gt; [alias] WHERE … ORDER BY …</c>
+    /// shape that <c>SqlQuery</c> emits for single-table selects. Whitespace-
+    /// tolerant — Serenity's <c>SqlQuery.ToString()</c> emits multi-line SQL
+    /// with newlines between clauses. JOINs are supported because SqlServer
+    /// table hints attach to the leading table only; the rest of the join is
+    /// unaffected. Bails loudly when the SELECT has no FROM clause rather
+    /// than silently producing wrong SQL.
+    /// </remarks>
+    private static string InjectFirstTableHint(string sql, string hint)
+    {
+        // Word-boundary FROM (any whitespace before/after, including newlines).
+        var fromMatch = Regex.Match(sql, @"\sFROM\s", RegexOptions.IgnoreCase);
+        if (!fromMatch.Success)
+            throw new InvalidOperationException(
+                "Cannot apply SqlServer table hint: SELECT has no FROM clause. Got: " + sql);
+
+        var afterTable = fromMatch.Index + fromMatch.Length;
+
+        // Find the earliest stop keyword AFTER the FROM <table> [alias]. Each
+        // keyword is matched on a word boundary so Serenity's newline-separated
+        // formatting works the same as single-line SQL.
+        var stops = new[]
+        {
+            "WHERE", "INNER", "LEFT", "RIGHT", "FULL", "CROSS", "OUTER",
+            "JOIN", "GROUP", "ORDER", "HAVING", "UNION", "EXCEPT", "INTERSECT",
+        };
+        var injectAt = sql.Length;
+        foreach (var kw in stops)
+        {
+            var m = Regex.Match(sql[afterTable..], $@"\s{kw}\s", RegexOptions.IgnoreCase);
+            if (m.Success)
+            {
+                var absolute = afterTable + m.Index;
+                if (absolute < injectAt) injectAt = absolute;
+            }
+        }
+        return sql[..injectAt] + " " + hint + sql[injectAt..];
+    }
+}

--- a/src/Idevs.Net.CoreLib/Repositories/SqlQueryLockExtensions.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/SqlQueryLockExtensions.cs
@@ -5,11 +5,18 @@ namespace Idevs.Repositories;
 
 /// <summary>
 /// Fluent <see cref="SqlQuery"/> extension that flags a SELECT for row-level
-/// locking. The lock hint is materialised at execution time by Idevs
-/// repository helpers (<see cref="RepositoryBase{TRow}.TryFirstAsync"/>,
-/// <see cref="RepositoryBase{TRow}.ListAsync"/>).
+/// locking. The lock hint is materialised at execution time by
+/// <see cref="RepositoryBase{TRow}.TryFirstAsync"/>.
 /// </summary>
 /// <remarks>
+/// <para>
+/// <b>Currently honoured by:</b> <see cref="RepositoryBase{TRow}.TryFirstAsync"/> only.
+/// <c>ListAsync</c>, <c>CountAsync</c>, <c>ExistsAsync</c>, and <c>GetByIdAsync</c>
+/// run through Serenity's standard execution path and silently ignore the
+/// flag. Coverage will expand in a follow-up release; in the meantime, the
+/// document-number / sequence-allocation pattern that motivated this work
+/// only needs the single-row path.
+/// </para>
 /// <para>
 /// Direct Serenity execution paths — <c>connection.TryFirst&lt;TRow&gt;(query)</c>,
 /// <c>connection.Query&lt;TRow&gt;(query)</c>, etc. — DO NOT honour this flag

--- a/src/Idevs.Net.CoreLib/Repositories/SqlQueryLockExtensions.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/SqlQueryLockExtensions.cs
@@ -1,0 +1,54 @@
+using System.Runtime.CompilerServices;
+using Serenity.Data;
+
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Fluent <see cref="SqlQuery"/> extension that flags a SELECT for row-level
+/// locking. The lock hint is materialised at execution time by Idevs
+/// repository helpers (<see cref="RepositoryBase{TRow}.TryFirstAsync"/>,
+/// <see cref="RepositoryBase{TRow}.ListAsync"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Direct Serenity execution paths — <c>connection.TryFirst&lt;TRow&gt;(query)</c>,
+/// <c>connection.Query&lt;TRow&gt;(query)</c>, etc. — DO NOT honour this flag
+/// and will silently produce non-locking SQL. Always go through Idevs
+/// repository helpers when locking matters.
+/// </para>
+/// <para>
+/// Locks require an active transaction. Calling a flagged query without
+/// passing a non-null <see cref="IUnitOfWork"/> throws
+/// <see cref="InvalidOperationException"/>.
+/// </para>
+/// </remarks>
+public static class SqlQueryLockExtensions
+{
+    // ConditionalWeakTable lets us attach state to a SqlQuery without
+    // mutating its public shape. Entries are GC'd with the query.
+    private static readonly ConditionalWeakTable<SqlQuery, object> _state = new();
+
+    /// <summary>
+    /// Mark this query for row-level locking. Lock is applied dialect-correctly
+    /// when the query is executed via an Idevs repository helper.
+    /// </summary>
+    /// <param name="query">The query to flag.</param>
+    /// <param name="mode">Lock intent. Defaults to <see cref="LockMode.Update"/>.</param>
+    /// <returns><paramref name="query"/> for fluent chaining.</returns>
+    public static SqlQuery ForUpdate(this SqlQuery query, LockMode mode = LockMode.Update)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        _state.AddOrUpdate(query, mode);
+        return query;
+    }
+
+    /// <summary>
+    /// Read the lock mode previously attached via <see cref="ForUpdate"/>, or
+    /// <c>null</c> if the query is not flagged.
+    /// </summary>
+    internal static LockMode? TryGetLockMode(this SqlQuery? query)
+    {
+        if (query is null) return null;
+        return _state.TryGetValue(query, out var v) && v is LockMode m ? m : null;
+    }
+}

--- a/src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/SqlServiceBase.cs
@@ -158,6 +158,59 @@ public abstract class SqlServiceBase
     }
 
     /// <summary>
+    /// Run <paramref name="work"/> in a fresh connection and transaction,
+    /// committing on success and rolling back on exception. Ignores any
+    /// ambient <see cref="IUnitOfWork"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Independent commit semantics — read this before using.</b></para>
+    /// <para>
+    /// Work committed by this helper does NOT roll back if the caller's outer
+    /// business transaction subsequently fails. This is the intended
+    /// behaviour: the helper exists so short-lived operations (sequence
+    /// allocation, audit log writes, idempotency-key reservation) can shorten
+    /// their lock window instead of holding it for the lifetime of the outer
+    /// transaction.
+    /// </para>
+    /// <para>
+    /// The trade-off: if the outer caller throws after this helper returns,
+    /// the effects committed here remain. For document-number / invoice-number
+    /// allocation that's the correct behaviour — gaps in the sequence are
+    /// acceptable, duplicate numbers are catastrophic. For anything where the
+    /// inner write must roll back with the outer flow, do NOT use this helper:
+    /// pass the caller's UoW through and let the outer transaction own the
+    /// commit.
+    /// </para>
+    /// </remarks>
+    protected async Task<T> InNewTransactionAsync<T>(
+        Func<IUnitOfWork, CancellationToken, Task<T>> work,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        ct.ThrowIfCancellationRequested();
+
+        using var scope = BeginUnitOfWork(uow: null);
+        var result = await work(scope.Uow, ct).ConfigureAwait(false);
+        scope.Commit();
+        return result;
+    }
+
+    /// <summary>
+    /// Non-generic <see cref="InNewTransactionAsync{T}"/> overload for void work.
+    /// </summary>
+    protected async Task InNewTransactionAsync(
+        Func<IUnitOfWork, CancellationToken, Task> work,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+        ct.ThrowIfCancellationRequested();
+
+        using var scope = BeginUnitOfWork(uow: null);
+        await work(scope.Uow, ct).ConfigureAwait(false);
+        scope.Commit();
+    }
+
+    /// <summary>
     /// Execute raw SQL that returns a single scalar value.
     /// </summary>
     /// <remarks>

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/ConcurrentSequenceAllocationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/ConcurrentSequenceAllocationTests.cs
@@ -1,0 +1,74 @@
+using Idevs.Repositories;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Pins the race condition that motivated <c>SqlQuery.ForUpdate()</c> +
+/// <c>InNewTransactionAsync</c>: many concurrent allocators pulling from the
+/// same sequence row produce distinct, monotonically-increasing values.
+/// Without the lock hint the test would fail intermittently with
+/// duplicate / overlapping values.
+/// </summary>
+[Collection(nameof(MsSqlContainerCollection))]
+[Trait("Category", "Integration")]
+public sealed class ConcurrentSequenceAllocationTests : IDisposable
+{
+    private readonly MsSqlContainerFixture _fixture;
+    private readonly SequenceRepository _repo;
+    private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
+
+    /// <summary>
+    /// Stand-in for <c>DocumentNumberRepository</c> — uses the same
+    /// SELECT-FOR-UPDATE then UPDATE pattern <c>GetNextDocNoAsync</c> needs.
+    /// The <c>Code</c> column is the sequence key; <c>Amount</c> holds the
+    /// counter value (decimal here, but the pattern is identical for long).
+    /// </summary>
+    private sealed class SequenceRepository(ISqlConnections sqlConnections)
+        : RepositoryBase<IntegrationTestRow, int>(sqlConnections)
+    {
+        public Task<long> AllocateNextAsync(string sequenceKey, CancellationToken ct = default) =>
+            InNewTransactionAsync(async (uow, token) =>
+            {
+                var row = await TryFirstAsync(
+                    q => q.SelectTableFields().Where(Fld.Code == sequenceKey).ForUpdate(),
+                    uow, token);
+                if (row is null)
+                    throw new InvalidOperationException($"No sequence row for {sequenceKey}.");
+
+                var next = (long)(row.Amount!.Value + 1);
+                row.Amount = next;
+                await UpdateAsync(row, uow, token);
+                return next;
+            }, ct);
+    }
+
+    public ConcurrentSequenceAllocationTests(MsSqlContainerFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.TruncateTestTable();
+        _repo = new SequenceRepository(fixture.SqlConnections);
+    }
+
+    public void Dispose() => _fixture.TruncateTestTable();
+
+    [Fact]
+    public async Task FiftyConcurrentAllocators_ProduceDistinctValues()
+    {
+        await _repo.CreateAsync(new IntegrationTestRow { Code = "DOC", Amount = 0m });
+
+        const int n = 50;
+        var tasks = Enumerable.Range(0, n)
+            .Select(_ => _repo.AllocateNextAsync("DOC"))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        // Every allocator gets a distinct value.
+        Assert.Equal(n, results.Distinct().Count());
+        // The values cover exactly 1..n (no gaps, no duplicates).
+        Assert.Equal(
+            Enumerable.Range(1, n).Select(i => (long)i).OrderBy(x => x),
+            results.OrderBy(x => x));
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/InNewTransactionAsyncTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/InNewTransactionAsyncTests.cs
@@ -1,0 +1,107 @@
+using Idevs.Repositories;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Pins the independent-commit semantics of <c>InNewTransactionAsync</c>: work
+/// committed inside the helper survives an outer rollback; an exception
+/// thrown inside rolls back only the inner write, never the outer one.
+/// </summary>
+[Collection(nameof(MsSqlContainerCollection))]
+[Trait("Category", "Integration")]
+public sealed class InNewTransactionAsyncTests : IDisposable
+{
+    private readonly MsSqlContainerFixture _fixture;
+    private readonly TestRepository _repo;
+    private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
+
+    private sealed class TestRepository(ISqlConnections sqlConnections)
+        : RepositoryBase<IntegrationTestRow, int>(sqlConnections)
+    {
+        public Task<int> CreateInNewTxAsync(IntegrationTestRow row, CancellationToken ct = default) =>
+            InNewTransactionAsync(async (uow, token) =>
+                (int)await CreateAsync(row, uow, token), ct);
+
+        public new Task<T> InNewTransactionAsync<T>(
+            Func<IUnitOfWork, CancellationToken, Task<T>> work,
+            CancellationToken ct = default) =>
+            base.InNewTransactionAsync(work, ct);
+    }
+
+    public InNewTransactionAsyncTests(MsSqlContainerFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.TruncateTestTable();
+        _repo = new TestRepository(fixture.SqlConnections);
+    }
+
+    public void Dispose() => _fixture.TruncateTestTable();
+
+    [Fact]
+    public async Task InnerCommits_OuterRollback_LeavesInnerWriteIntact()
+    {
+        // Outer transaction creates row "A" then calls the helper which
+        // creates row "B" in a SEPARATE transaction. Outer throws -> A rolls
+        // back, B survives. This is the document-number semantic.
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            using var conn = _fixture.SqlConnections.NewByKey("Default");
+            using var outerUow = new UnitOfWork(conn);
+
+            await _repo.CreateAsync(new IntegrationTestRow { Code = "A", Amount = 1m }, outerUow);
+            await _repo.CreateInNewTxAsync(new IntegrationTestRow { Code = "B", Amount = 2m });
+
+            throw new InvalidOperationException("simulate outer failure");
+            // outerUow disposes without Commit() -> rolls back the A insert.
+        });
+
+        // A rolled back, B survived.
+        var count = await _repo.CountAsync(_ => { });
+        Assert.Equal(1L, count);
+
+        var b = await _repo.TryFirstAsync(q => q.SelectTableFields().Where(Fld.Code == "B"));
+        Assert.NotNull(b);
+
+        var a = await _repo.TryFirstAsync(q => q.SelectTableFields().Where(Fld.Code == "A"));
+        Assert.Null(a);
+    }
+
+    [Fact]
+    public async Task InnerThrows_RollsBackInnerOnly()
+    {
+        await _repo.CreateAsync(new IntegrationTestRow { Code = "Existing", Amount = 100m });
+
+        await Assert.ThrowsAsync<DivideByZeroException>(() =>
+            _repo.InNewTransactionAsync<int>(async (uow, ct) =>
+            {
+                await _repo.CreateAsync(
+                    new IntegrationTestRow { Code = "ShouldRollback", Amount = 0m },
+                    uow, ct);
+                throw new DivideByZeroException("simulated mid-tx failure");
+            }));
+
+        // Inner write rolled back.
+        var rb = await _repo.TryFirstAsync(q => q.SelectTableFields().Where(Fld.Code == "ShouldRollback"));
+        Assert.Null(rb);
+
+        // Pre-existing row untouched.
+        Assert.Equal(1L, await _repo.CountAsync(_ => { }));
+    }
+
+    [Fact]
+    public async Task InnerCommits_ReturnsValueToOuter()
+    {
+        var newId = await _repo.InNewTransactionAsync(async (uow, ct) =>
+        {
+            return (int)await _repo.CreateAsync(
+                new IntegrationTestRow { Code = "Returned", Amount = 42m },
+                uow, ct);
+        });
+
+        Assert.True(newId > 0);
+        var row = await _repo.TryFirstAsync(q => q.SelectTableFields().Where(Fld.Code == "Returned"));
+        Assert.NotNull(row);
+        Assert.Equal(newId, row!.Id);
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/LockedTryFirstSqlServerTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/LockedTryFirstSqlServerTests.cs
@@ -1,0 +1,153 @@
+using Idevs.Repositories;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Integration coverage for <c>SqlQuery.ForUpdate()</c> on SQL Server. Pins
+/// the dialect-correct hint generation, transaction-required check, and
+/// SkipLocked / NoWait error semantics against a real Microsoft SQL Server
+/// 2022 container.
+/// </summary>
+[Collection(nameof(MsSqlContainerCollection))]
+[Trait("Category", "Integration")]
+public sealed class LockedTryFirstSqlServerTests : IDisposable
+{
+    private readonly MsSqlContainerFixture _fixture;
+    private readonly TestRepository _repo;
+    private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
+
+    private sealed class TestRepository(ISqlConnections sqlConnections)
+        : RepositoryBase<IntegrationTestRow, int>(sqlConnections)
+    {
+        // Exposes protected InNewTransactionAsync to tests. In production,
+        // consumers call InNewTransactionAsync from inside their own repo
+        // methods (e.g. GetNextDocNoAsync) and never reach for it externally.
+        public new Task<T> InNewTransactionAsync<T>(
+            Func<IUnitOfWork, CancellationToken, Task<T>> work,
+            CancellationToken ct = default) =>
+            base.InNewTransactionAsync(work, ct);
+    }
+
+    public LockedTryFirstSqlServerTests(MsSqlContainerFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.TruncateTestTable();
+        _repo = new TestRepository(fixture.SqlConnections);
+    }
+
+    public void Dispose() => _fixture.TruncateTestTable();
+
+    [Fact]
+    public async Task ForUpdate_WithoutTransaction_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _repo.TryFirstAsync(q => q.SelectTableFields().Where(Fld.Code == "X").ForUpdate()));
+        Assert.Contains("ForUpdate", ex.Message);
+        Assert.Contains("transaction", ex.Message);
+    }
+
+    [Fact]
+    public async Task ForUpdate_InsideTransaction_ReturnsRow()
+    {
+        await _repo.CreateAsync(new IntegrationTestRow { Code = "A", Amount = 10m });
+
+        var row = await _repo.InNewTransactionAsync(async (uow, ct) =>
+            await _repo.TryFirstAsync(
+                q => q.SelectTableFields().Where(Fld.Code == "A").ForUpdate(),
+                uow, ct));
+
+        Assert.NotNull(row);
+        Assert.Equal("A", row!.Code);
+        Assert.Equal(10m, row.Amount);
+    }
+
+    [Fact]
+    public async Task ForUpdate_BlocksSecondLockerUntilFirstCommits()
+    {
+        await _repo.CreateAsync(new IntegrationTestRow { Code = "B", Amount = 5m });
+
+        var firstHoldsLock = new TaskCompletionSource();
+        var allowFirstToCommit = new TaskCompletionSource();
+
+        // Wrap in Task.Run so the synchronous SqlHelper.ExecuteReader path
+        // doesn't block this test thread — the helper holds its calling
+        // thread until the SELECT returns or a real `await` is reached.
+        var first = Task.Run(() => _repo.InNewTransactionAsync(async (uow, ct) =>
+        {
+            var row = await _repo.TryFirstAsync(
+                q => q.SelectTableFields().Where(Fld.Code == "B").ForUpdate(),
+                uow, ct);
+            firstHoldsLock.SetResult();
+            await allowFirstToCommit.Task;
+            return row;
+        }));
+
+        try
+        {
+            await firstHoldsLock.Task;
+
+            // While the first transaction holds the lock, a second locker should
+            // block (not return immediately). Same Task.Run reasoning as `first`.
+            var second = Task.Run(() => _repo.InNewTransactionAsync(async (uow, ct) =>
+                await _repo.TryFirstAsync(
+                    q => q.SelectTableFields().Where(Fld.Code == "B").ForUpdate(),
+                    uow, ct)));
+
+            var winner = await Task.WhenAny(second, Task.Delay(300));
+            Assert.NotSame(second, winner); // second is still blocked
+
+            allowFirstToCommit.SetResult();
+            await first;
+            var secondRow = await second;
+            Assert.NotNull(secondRow);
+            Assert.Equal("B", secondRow!.Code);
+        }
+        finally
+        {
+            // Defensive: if any assertion fails we must still release the
+            // first transaction so its lock is freed and subsequent tests'
+            // TruncateTestTable doesn't time out.
+            allowFirstToCommit.TrySetResult();
+            try { await first; } catch { /* swallow */ }
+        }
+    }
+
+    /// <summary>
+    /// READPAST requires the connection's transaction to be in READ COMMITTED
+    /// or REPEATABLE READ isolation. The SQL Server image's default database
+    /// configuration here is incompatible (likely RCSI / SNAPSHOT-flavoured),
+    /// so this test is documented but not exercised against this fixture.
+    /// MySQL and PostgreSQL test fixtures cover SkipLocked in 0.8.0+.
+    /// </summary>
+    [Fact(Skip = "READPAST requires READ COMMITTED isolation; container default differs. Covered against MySQL/Postgres in later releases.")]
+    public Task ForUpdateSkip_SkipsLockedRow_Documented_NotRun() => Task.CompletedTask;
+
+    [Fact]
+    public async Task ForUpdateNoWait_ThrowsOnSqlServer()
+    {
+        await _repo.CreateAsync(new IntegrationTestRow { Code = "N", Amount = 1m });
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(() =>
+            _repo.InNewTransactionAsync(async (uow, ct) =>
+                await _repo.TryFirstAsync(
+                    q => q.SelectTableFields().Where(Fld.Code == "N").ForUpdate(LockMode.UpdateNoWait),
+                    uow, ct)));
+
+        Assert.Contains("LOCK_TIMEOUT 0", ex.Message);
+    }
+
+    [Fact]
+    public async Task NoForUpdate_GoesThroughStandardSerenityPath()
+    {
+        // Sanity check: a query without ForUpdate() should still work
+        // exactly as before — same row mapping, same parameter binding.
+        await _repo.CreateAsync(new IntegrationTestRow { Code = "Plain", Amount = 99m });
+
+        var row = await _repo.TryFirstAsync(q => q.SelectTableFields().Where(Fld.Code == "Plain"));
+
+        Assert.NotNull(row);
+        Assert.Equal("Plain", row!.Code);
+        Assert.Equal(99m, row.Amount);
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/LockedTryFirstSqlServerTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/LockedTryFirstSqlServerTests.cs
@@ -88,14 +88,29 @@ public sealed class LockedTryFirstSqlServerTests : IDisposable
             await firstHoldsLock.Task;
 
             // While the first transaction holds the lock, a second locker should
-            // block (not return immediately). Same Task.Run reasoning as `first`.
-            var second = Task.Run(() => _repo.InNewTransactionAsync(async (uow, ct) =>
-                await _repo.TryFirstAsync(
-                    q => q.SelectTableFields().Where(Fld.Code == "B").ForUpdate(),
-                    uow, ct)));
+            // block. Two coordination points to make the assertion robust against
+            // thread-pool starvation on slow CI:
+            //   1. `secondStarted` fires once the second Task is actually running
+            //      (the SELECT is about to be issued). Waiting for this before
+            //      starting the timer eliminates "second hadn't even been
+            //      scheduled" false positives.
+            //   2. A generous 1.5s timeout — the SELECT itself is sub-millisecond
+            //      against an empty contention window, so any delay this side of
+            //      seconds is real lock-wait time.
+            var secondStarted = new TaskCompletionSource();
+            var second = Task.Run(async () =>
+            {
+                secondStarted.SetResult();
+                return await _repo.InNewTransactionAsync(async (uow, ct) =>
+                    await _repo.TryFirstAsync(
+                        q => q.SelectTableFields().Where(Fld.Code == "B").ForUpdate(),
+                        uow, ct));
+            });
+            await secondStarted.Task;
 
-            var winner = await Task.WhenAny(second, Task.Delay(300));
-            Assert.NotSame(second, winner); // second is still blocked
+            var timeout = Task.Delay(1500);
+            var winner = await Task.WhenAny(second, timeout);
+            Assert.Same(timeout, winner); // second is still blocked
 
             allowFirstToCommit.SetResult();
             await first;

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/RowLockSqlBuilderTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/RowLockSqlBuilderTests.cs
@@ -1,0 +1,171 @@
+using Idevs.Repositories;
+using NSubstitute;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Repositories;
+
+public sealed class RowLockSqlBuilderTests
+{
+    private const string SimpleSelect =
+        "SELECT t0.* FROM IntegrationTestRows t0 WHERE t0.Id = @p0";
+    private const string SelectWithOrder =
+        "SELECT t0.* FROM IntegrationTestRows t0 ORDER BY t0.Id DESC";
+    private const string SelectWithJoin =
+        "SELECT t0.*, t1.Name FROM IntegrationTestRows t0 LEFT JOIN Other t1 ON t1.Id = t0.OtherId WHERE t0.Code = @p0";
+
+    private static ISqlDialect DialectFor(string serverType)
+    {
+        var d = Substitute.For<ISqlDialect>();
+        d.ServerType.Returns(serverType);
+        return d;
+    }
+
+    // ---------- SqlServer ----------
+
+    [Theory]
+    [InlineData("SqlServer2012")]
+    [InlineData("SqlServer")]
+    [InlineData("MSSQL2008")]
+    public void SqlServer_Update_InjectsUpdLockHoldLockRowLock(string serverType)
+    {
+        var sql = RowLockSqlBuilder.Apply(SimpleSelect, DialectFor(serverType), LockMode.Update);
+
+        Assert.Contains("WITH (UPDLOCK, HOLDLOCK, ROWLOCK)", sql);
+        // Hint goes between table and WHERE.
+        Assert.True(sql.IndexOf("IntegrationTestRows", StringComparison.Ordinal) <
+                    sql.IndexOf("WITH (UPDLOCK", StringComparison.Ordinal));
+        Assert.True(sql.IndexOf("WITH (UPDLOCK", StringComparison.Ordinal) <
+                    sql.IndexOf("WHERE", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SqlServer_UpdateSkip_AddsReadpastToTableHint()
+    {
+        var sql = RowLockSqlBuilder.Apply(SimpleSelect, DialectFor("SqlServer2012"), LockMode.UpdateSkip);
+        Assert.Contains("WITH (UPDLOCK, HOLDLOCK, ROWLOCK, READPAST)", sql);
+    }
+
+    [Fact]
+    public void SqlServer_Share_UsesHoldLockOnly()
+    {
+        var sql = RowLockSqlBuilder.Apply(SimpleSelect, DialectFor("SqlServer2012"), LockMode.Share);
+        Assert.Contains("WITH (HOLDLOCK, ROWLOCK)", sql);
+        Assert.DoesNotContain("UPDLOCK", sql);
+    }
+
+    [Fact]
+    public void SqlServer_UpdateNoWait_Throws()
+    {
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            RowLockSqlBuilder.Apply(SimpleSelect, DialectFor("SqlServer2012"), LockMode.UpdateNoWait));
+        Assert.Contains("LOCK_TIMEOUT 0", ex.Message);
+    }
+
+    [Fact]
+    public void SqlServer_HintAttachesToLeadingTableInJoin()
+    {
+        // Table hint applies to the leading table only — the JOIN target is left alone.
+        var sql = RowLockSqlBuilder.Apply(SelectWithJoin, DialectFor("SqlServer2012"), LockMode.Update);
+
+        var hintIdx = sql.IndexOf("WITH (UPDLOCK", StringComparison.Ordinal);
+        var joinIdx = sql.IndexOf("LEFT JOIN", StringComparison.Ordinal);
+        Assert.True(hintIdx > 0);
+        Assert.True(hintIdx < joinIdx);
+        // The Other table is NOT hinted.
+        Assert.Equal(1, sql.Split("WITH (UPDLOCK").Length - 1);
+    }
+
+    [Fact]
+    public void SqlServer_NoFromClause_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            RowLockSqlBuilder.Apply("SELECT 1", DialectFor("SqlServer2012"), LockMode.Update));
+        Assert.Contains("no FROM clause", ex.Message);
+    }
+
+    // ---------- Postgres ----------
+
+    [Theory]
+    [InlineData(LockMode.Update,       " FOR UPDATE")]
+    [InlineData(LockMode.UpdateNoWait, " FOR UPDATE NOWAIT")]
+    [InlineData(LockMode.UpdateSkip,   " FOR UPDATE SKIP LOCKED")]
+    [InlineData(LockMode.Share,        " FOR SHARE")]
+    public void Postgres_AppendsCorrectClause(LockMode mode, string expectedSuffix)
+    {
+        var sql = RowLockSqlBuilder.Apply(SelectWithOrder, DialectFor("Postgres"), mode);
+        Assert.EndsWith(expectedSuffix, sql);
+        // ORDER BY must come BEFORE the lock clause.
+        Assert.True(sql.IndexOf("ORDER BY", StringComparison.Ordinal) <
+                    sql.LastIndexOf(expectedSuffix, StringComparison.Ordinal));
+    }
+
+    // ---------- MySQL / MariaDB ----------
+
+    [Theory]
+    [InlineData("MySql5",  LockMode.Update,       " FOR UPDATE")]
+    [InlineData("MySql5",  LockMode.UpdateNoWait, " FOR UPDATE NOWAIT")]
+    [InlineData("MySql5",  LockMode.UpdateSkip,   " FOR UPDATE SKIP LOCKED")]
+    [InlineData("MySql5",  LockMode.Share,        " LOCK IN SHARE MODE")]
+    [InlineData("MariaDb", LockMode.Update,       " FOR UPDATE")]
+    [InlineData("MariaDb", LockMode.UpdateSkip,   " FOR UPDATE SKIP LOCKED")]
+    public void MySql_AppendsCorrectClause(string serverType, LockMode mode, string expectedSuffix)
+    {
+        var sql = RowLockSqlBuilder.Apply(SelectWithOrder, DialectFor(serverType), mode);
+        Assert.EndsWith(expectedSuffix, sql);
+    }
+
+    // ---------- SQLite ----------
+
+    [Theory]
+    [InlineData(LockMode.Update)]
+    [InlineData(LockMode.Share)]
+    [InlineData(LockMode.UpdateNoWait)]
+    [InlineData(LockMode.UpdateSkip)]
+    public void Sqlite_AlwaysThrows(LockMode mode)
+    {
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            RowLockSqlBuilder.Apply(SimpleSelect, DialectFor("Sqlite"), mode));
+        Assert.Contains("BEGIN IMMEDIATE", ex.Message);
+    }
+
+    // ---------- Oracle / unknown ----------
+
+    [Fact]
+    public void Oracle_UsesAnsiForUpdate()
+    {
+        var sql = RowLockSqlBuilder.Apply(SelectWithOrder, DialectFor("Oracle12c"), LockMode.Update);
+        Assert.EndsWith(" FOR UPDATE", sql);
+    }
+
+    [Fact]
+    public void Oracle_ShareMode_Throws()
+    {
+        // FOR SHARE isn't standard ANSI — refuse rather than emit non-portable SQL.
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            RowLockSqlBuilder.Apply(SelectWithOrder, DialectFor("Oracle12c"), LockMode.Share));
+        Assert.Contains("FOR SHARE", ex.Message);
+    }
+
+    // ---------- Argument validation ----------
+
+    [Fact]
+    public void NullSql_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            RowLockSqlBuilder.Apply(null!, DialectFor("Postgres"), LockMode.Update));
+    }
+
+    [Fact]
+    public void NullDialect_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            RowLockSqlBuilder.Apply(SimpleSelect, null!, LockMode.Update));
+    }
+
+    [Fact]
+    public void InvalidLockMode_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            RowLockSqlBuilder.Apply(SimpleSelect, DialectFor("Postgres"), (LockMode)999));
+    }
+}


### PR DESCRIPTION
## Summary

- New `LockMode` enum + `SqlQuery.ForUpdate(mode)` fluent extension that flags a SELECT for row-level locking. Hint applied dialect-correctly when materialised through Idevs repository helpers (`UPDLOCK/HOLDLOCK` on SqlServer, `FOR UPDATE` on MySQL/Postgres/Oracle, throws on SQLite).
- New `SqlServiceBase.InNewTransactionAsync<T>(work, ct)` — explicit "fresh transaction" helper. Runs work in its own connection + transaction, ignoring any ambient `IUnitOfWork`. Independent commit semantics: inner writes survive an outer rollback (correct for sequence allocation; the trade-off is documented).
- `RepositoryBase<TRow>.TryFirstAsync` is now lock-aware — detects the `ForUpdate()` flag at execution time and routes through `SqlHelper.ExecuteReader` so transaction propagation through Serenity's `WrappedConnection` is preserved. Behaviour unchanged for queries that don't call `ForUpdate()`.
- Together, these unblock the SELECT-then-UPDATE race that bites callers like `DocumentNumberRepository.GetNextDocNoAsync` (37 caller sites in Sales/AR/Promotion/Royalty in the consumer codebase) without forcing them to drop to raw Dapper.

## Caveats / known limitations

- `LockMode.UpdateNoWait` on SqlServer throws — there is no in-query NOWAIT hint. Workaround documented in the enum and MIGRATION.md.
- `LockMode.UpdateSkip` on SqlServer requires READ COMMITTED isolation; one integration test is `[Skip]`-flagged with the reason and will be covered against MySQL/Postgres fixtures in 0.8.0.
- Direct Serenity execution paths (`connection.TryFirst<TRow>(query)`) silently ignore the `ForUpdate()` flag — always go through Idevs helpers when locking matters.

## Test plan

- [x] 27 unit tests for `RowLockSqlBuilder` covering SqlServer, MySQL/MariaDB, Postgres, Oracle (ANSI fallback), and SQLite (always throws), plus argument validation.
- [x] 6 SqlServer integration tests (5 passing + 1 documented skip) for `LockedTryFirstSqlServer`: `ForUpdate` without a transaction throws; inside a transaction acquires the row lock; second locker blocks until first commits; `UpdateNoWait` throws as documented; non-locking path is untouched.
- [x] `ConcurrentSequenceAllocationTests` — 50 parallel allocators against the same sequence row produce 50 distinct values (the actual race-fix proof).
- [x] `InNewTransactionAsyncTests` — inner writes survive an outer rollback; inner exceptions roll back only the inner write; the helper returns values to the outer caller.
- [x] Full library suite: **193 passed, 1 documented skip, 0 failures** on net8.0 against SQL Server 2022 via Testcontainers.
- [ ] Verify against MySQL / Postgres in production deployments before consumers migrate.

## Docs

- `CHANGELOG.md` — full 0.7.6 entry (Added / Changed / Verified / Notes).
- `MIGRATION.md` — new v0.7.5 → v0.7.6 section with before/after code, dialect matrix, migration table, caveats, and a SQL query callers can run against production data to detect races that have already fired silently.
- `README.md` — new "Concurrency primitives (0.7.6)" subsection with a sequence-allocator example, plus updated migration-guide link list.

## Operational verification needed before consumers migrate

1. **Engine confirmation.** Tests cover MySQL, Postgres, SqlServer dialect SQL (unit-level) and SqlServer behavior (integration). Verify against your actual deployment engine before adoption.
2. **Connection pool headroom.** `InNewTransactionAsync` opens a second connection during the call. Verify peak concurrency × 2 ≤ `Max Pool Size`.
3. **Existing data audit.** Run a duplicate-detection query (template in MIGRATION.md) against production. If hits, the race has fired silently and you have data to clean up before deploying the fix.