### PR TITLE
chore: bump packable projects to 0.7.6 for nuget publish

### DIFF
--- a/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
+++ b/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Autofac</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <Description>Optional Autofac integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
+++ b/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Idevs.Net.CoreLib.Generators.Abstractions</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <PackageTags>Idevs; CoreLib; Roslyn; SourceGenerator; Helpers</PackageTags>
     <Description>Reusable Roslyn helpers for source generators that integrate with Idevs.Net.CoreLib's DI conventions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
+++ b/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Serilog</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <Description>Optional Serilog integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary

Bumps `<Version>` in all four packable csproj files from `0.7.5` to `0.7.6` so the 0.7.6 release lands on NuGet. PR #16 shipped the row-lock primitives + `InNewTransactionAsync` but landed on `main` without a version bump, which means no package would be produced on the next publish run.

Files touched:

- `src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj`
- `src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj`
- `src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj`
- `src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj`

The `Idevs.Net.CoreLib.Generators` project is `IsPackable=false` and intentionally has no `Version` element.

## Test plan

- [x] `dotnet build -c Release` produces all four `0.7.6.nupkg` files cleanly:
  - `Idevs.Net.CoreLib.0.7.6.nupkg`
  - `Idevs.Net.CoreLib.Autofac.0.7.6.nupkg`
  - `Idevs.Net.CoreLib.Generators.Abstractions.0.7.6.nupkg`
  - `Idevs.Net.CoreLib.Serilog.0.7.6.nupkg`
- [x] No code changes — purely metadata.