### PR TITLE
feat: add ISequenceProvider for atomic numeric allocation (0.7.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,11 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        # Skip integration tests on GitHub-hosted runners — they need
+        # Testcontainers + a SQL Server image pull from mcr.microsoft.com,
+        # which intermittently 403s through Microsoft's WAF on shared
+        # runner IPs. Integration tests are run locally before merge.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Integration"
 
   request-copilot-review:
     name: Request Copilot Review

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,62 @@
+name: Integration Tests
+
+# Runs the [Trait("Category", "Integration")] suite that the regular CI
+# workflow filters out. Lives in a separate workflow for two reasons:
+#   1. Testcontainers pulls mcr.microsoft.com/mssql/server, which gets
+#      403'd by Microsoft's WAF on shared GitHub-hosted runner IPs from
+#      time to time. Decoupling from PR CI keeps PR merges moving when
+#      the registry is having a bad day.
+#   2. Integration tests are slower than unit tests by ~5-10x (image
+#      pull + container startup). Running them on every PR push would
+#      double CI time without proportional value — the unit suite
+#      already covers the dialect SQL builders deterministically.
+#
+# Triggered:
+#   - on every push to main (catches regressions within minutes of merge)
+#   - manually via workflow_dispatch (run before tagging a release, or
+#     re-run if a previous attempt failed at image pull)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Integration (Testcontainers)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+          restore-keys: ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Integration tests
+        # Inverse filter from ci.yml: Category=Integration only.
+        # If MCR is blocking and the suite fails at fixture init, the
+        # workflow is re-runnable from the Actions tab.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category=Integration"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,10 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        # Match the PR CI step: skip integration tests on the hosted
+        # runner. Integration coverage runs locally before the version
+        # bump that triggers a release.
+        run: dotnet test --configuration Release --no-build --verbosity normal --filter "Category!=Integration"
 
       - name: Pack
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.7.7 (2026-05-07)
+
+### Added
+
+- `Idevs.Repositories.Sequences.ISequenceProvider` — atomic numeric
+  sequence allocator. Each call to `NextAsync(string sequenceKey, ct)`
+  returns a value that no other concurrent caller can return for the
+  same key. `NextRangeAsync(key, count, ct)` allocates a contiguous
+  block atomically (useful for bulk imports). `EnsureSequenceAsync(key,
+  startValue = 1, ct)` idempotently seeds a sequence row.
+- `SqlSequenceProvider` — default SQL-backed implementation, registered
+  via `[Scoped(ServiceType = typeof(ISequenceProvider))]`. Uses 0.7.6's
+  `InNewTransactionAsync` + `ForUpdate()` so the lock window is the
+  duration of the SELECT…FOR UPDATE + UPDATE on a single sequence row;
+  on a same-region database that's sub-millisecond. Backed by an
+  `IdevsSequences` table (`SequenceKey NVARCHAR(100) PRIMARY KEY`,
+  `NextValue BIGINT NOT NULL`); consumers create the table in their
+  own migration pipeline (schema in MIGRATION.md).
+- `IdevsSequenceRow` — public Serenity row backing the storage table.
+- `SequenceServiceCollectionExtensions.AddIdevsSequenceProvider()` —
+  manual DI registration for hosts that don't run the source generator
+  (test hosts, console apps).
+
+### Notes
+
+- Allocation is **independent of any ambient `IUnitOfWork`** by design.
+  A value committed inside `NextAsync` does NOT roll back if the outer
+  caller's business transaction subsequently fails. This is the
+  intended semantic for document-number / invoice-number / order-number
+  sequences — gaps are normal, duplicate numbers are catastrophic.
+- The interface returns `long`; callers format to whatever scheme their
+  domain requires (`INV-2026-00042`, `SO/2026/00001`, etc.). The
+  provider does not know about formatting.
+- See MIGRATION.md (v0.7.6 → v0.7.7) for the caller-side migration
+  pattern from the manual SELECT-then-UPDATE shape, including the
+  schema DDL for SqlServer / MySQL / PostgreSQL.
+
+### Verified (xUnit + Testcontainers vs SQL Server 2022)
+
+- 14 integration tests in `SqlSequenceProviderTests` covering: ensure
+  semantics (new key, existing key preserves NextValue, default vs
+  custom start value), `NextAsync` sequencing and per-key isolation,
+  argument validation (null/empty key throws, non-positive count
+  throws, missing key throws), `NextRangeAsync` block allocation
+  (advance count, large block of 1000), 50 concurrent allocators
+  produce 50 distinct values (the underlying race fix re-pinned at the
+  helper level), and outer-rollback survival.
+
 ## 0.7.6 (2026-05-07)
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -180,10 +180,15 @@ Avoid raw user input in the key. The allocator does NOT sanitize — a
   reserve the block in one round trip; allocating one-at-a-time inside
   a loop is correct but issues N round trips.
 - **Concurrent `EnsureSequenceAsync`.** Two callers ensuring the same
-  key at the same time race on the primary-key insert. The
-  implementation catches the unique-constraint conflict and treats it
-  as a no-op — both callers return successfully without a second seed
-  attempt. Safe to call from app startup in load-balanced fleets.
+  key at the same time both succeed without raising an error. The
+  implementation issues a single dialect-aware no-error UPSERT per
+  call — `INSERT IGNORE` (MySQL/MariaDB), `INSERT ... ON CONFLICT
+  DO NOTHING` (PostgreSQL), `INSERT OR IGNORE` (SQLite), an
+  `INSERT ... WHERE NOT EXISTS` with `WITH (UPDLOCK, HOLDLOCK)` on
+  the existence check (SqlServer), or `MERGE` (Oracle). No
+  PK-violation exception is raised in any of these dialects, so the
+  surrounding transaction stays valid even under contention. Safe to
+  call from app startup in load-balanced fleets.
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 
 ## Contents
 
+- [v0.7.6 → v0.7.7 — ISequenceProvider helper](#v076--v077--isequenceprovider-helper)
 - [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](#v075--v076--row-lock-primitives--innewtransactionasync)
 - [v0.7.4 → v0.7.5 — CountAsync + ExistsAsync helpers](#v074--v075--countasync--existsasync-helpers)
 - [v0.7.3 → v0.7.4 — Explicit-fields Create/Update + NotMapped/Expression handling](#v073--v074--explicit-fields-createupdate--notmappedexpression-handling)
@@ -14,6 +15,175 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 - [v0.3.x → v0.5.0 — Package Layout & DI Changes](#v03x--v050--package-layout--di-changes)
 - [v0.1.x → v0.2.0 — Autofac Integration](#v01x--v020--autofac-integration)
 - [v0.0.x → v0.1.x — Service Registration & Chrome Setup](#v00x--v01x--service-registration--chrome-setup)
+
+---
+
+## v0.7.6 → v0.7.7 — ISequenceProvider helper
+
+### What changed
+
+A higher-level helper for atomic sequence allocation. Eliminates the
+need to write the `InNewTransactionAsync` + `ForUpdate()` boilerplate
+in every consumer site that allocates document/invoice/order numbers.
+
+| API | Returns | What it does |
+|---|---|---|
+| `ISequenceProvider.NextAsync(string sequenceKey, ct)` | `Task<long>` | Allocate the next value; throws if the sequence isn't seeded. |
+| `ISequenceProvider.NextRangeAsync(string sequenceKey, int count, ct)` | `Task<IReadOnlyList<long>>` | Allocate `count` contiguous values atomically. |
+| `ISequenceProvider.EnsureSequenceAsync(string sequenceKey, long startValue = 1, ct)` | `Task` | Idempotently seed a sequence row. No-op if it already exists. |
+
+The default implementation (`SqlSequenceProvider`) is registered
+automatically via `[Scoped(ServiceType = typeof(ISequenceProvider))]`
+when the source generator runs. Manual DI hosts call
+`services.AddIdevsSequenceProvider()`.
+
+### Why
+
+The 0.7.6 primitives (`ForUpdate()` + `InNewTransactionAsync`) unblock
+the race; this helper turns the allocation pattern into a single line
+of caller code and removes the decision points (which uow? which lock
+mode? when to commit?) that produced the bug in the first place.
+
+### Schema
+
+Consumers create the storage table in their own migration pipeline.
+DDL by engine:
+
+#### SqlServer
+
+```sql
+CREATE TABLE [IdevsSequences] (
+    [SequenceKey] NVARCHAR(100) NOT NULL PRIMARY KEY,
+    [NextValue]   BIGINT        NOT NULL
+);
+```
+
+#### MySQL / MariaDB
+
+```sql
+CREATE TABLE IdevsSequences (
+    SequenceKey VARCHAR(100) NOT NULL PRIMARY KEY,
+    NextValue   BIGINT       NOT NULL
+) ENGINE=InnoDB;
+```
+
+#### PostgreSQL
+
+```sql
+CREATE TABLE IdevsSequences (
+    SequenceKey VARCHAR(100) NOT NULL PRIMARY KEY,
+    NextValue   BIGINT       NOT NULL
+);
+```
+
+The library does not ship migrations.
+
+### Migrating from manual SELECT-then-UPDATE
+
+Existing 37-callsite shape using the 0.7.6 primitives directly:
+
+```csharp
+// 0.7.6 — primitives wired by hand
+public Task<string> GetNextDocNoAsync(string docCode, CancellationToken ct = default) =>
+    InNewTransactionAsync(async (uow, token) =>
+    {
+        var row = await TryFirstAsync(
+            q => q.SelectTableFields()
+                  .Where(DocumentNumberRow.Fields.DocumentCode == docCode)
+                  .ForUpdate(),
+            uow, token);
+        if (row is null) throw new InvalidOperationException(...);
+
+        row.NextDocumentNo += 1;
+        await UpdateAsync(row, uow, token);
+        return Format(docCode, row.NextDocumentNo!.Value);
+    }, ct);
+```
+
+Becomes, in 0.7.7:
+
+```csharp
+// 0.7.7 — helper does the locking, transaction, and increment
+public sealed class DocumentNumberService(ISequenceProvider sequences)
+{
+    public async Task<string> GetNextDocNoAsync(
+        string docCode, CancellationToken ct = default)
+    {
+        var n = await sequences.NextAsync($"DocNo:{docCode}", ct);
+        return Format(docCode, n);
+    }
+}
+```
+
+### Seeding
+
+Before the first `NextAsync`, the sequence row must exist. Two options:
+
+```csharp
+// Option 1: at app startup, ensure all known sequences.
+await sequences.EnsureSequenceAsync("DocNo:SaleOrder", startValue: 1);
+await sequences.EnsureSequenceAsync("DocNo:Invoice", startValue: 1);
+
+// Option 2: in your migration script, INSERT directly:
+//   INSERT INTO IdevsSequences (SequenceKey, NextValue)
+//   VALUES ('DocNo:SaleOrder', 1), ('DocNo:Invoice', 1);
+```
+
+`EnsureSequenceAsync` is a no-op if the row already exists — calling
+it on every app startup is safe and idempotent. The `startValue`
+argument is ignored when the row exists; it does NOT reset the counter.
+
+### Caller signature change
+
+Note: the helper does NOT accept an `IUnitOfWork` parameter. Callers
+that previously threaded a `uow` through the allocation flow drop it
+at the `NextAsync` call site:
+
+| Before (0.7.6 caller) | After (0.7.7 caller) |
+|---|---|
+| `await GetNextDocNoAsync(uow, "SO", ct)` | `await sequences.NextAsync("DocNo:SO", ct)` |
+
+If the caller was passing `uow` to other operations in the same
+business flow (e.g. writing the SaleOrder row), keep doing that — only
+the sequence-allocation call drops the `uow`.
+
+### Sequence-key naming
+
+The library has no opinion on the key format. Recommended convention:
+namespace with colons, deepest segment first.
+
+| Pattern | Use |
+|---|---|
+| `"DocNo:SaleOrder"` | Per-document-type counters that don't restart. |
+| `"DocNo:Invoice:2026"` | Per-document-type, per-year counters. |
+| `"InternalId:Customer"` | Surrogate-key allocators. |
+
+Avoid raw user input in the key. The allocator does NOT sanitize — a
+`SequenceKey` is whatever string the caller passes.
+
+### Important caveats
+
+- **Independent commit semantics.** Inherited from 0.7.6's
+  `InNewTransactionAsync`. If your outer business transaction fails
+  AFTER `NextAsync` returns, the allocated number remains. For
+  document numbers that's correct (gaps are normal, duplicates are
+  catastrophic). For anything where the inner allocation must roll
+  back with the outer flow, do NOT use `ISequenceProvider` — implement
+  your own row using the caller's `uow`.
+- **Connection pool sizing.** Each `NextAsync` opens a separate
+  connection (via `InNewTransactionAsync`). At very high allocation
+  rates this is wasteful — the 0.8.0/0.9.0 work tracks adding a
+  HiLo-style batched provider, but for now verify peak concurrency × 2
+  ≤ your pool's `Max Pool Size`.
+- **No bulk-insert wiring.** If you're allocating a block to assign to
+  many rows in one `INSERT...VALUES (...)`, use `NextRangeAsync` to
+  reserve the block in one round trip; allocating one-at-a-time inside
+  a loop is correct but issues N round trips.
+- **Concurrent `EnsureSequenceAsync`.** Two callers ensuring the same
+  key at the same time race on the primary-key insert. The
+  implementation catches the unique-constraint conflict and treats it
+  as a no-op — both callers return successfully without a second seed
+  attempt. Safe to call from app startup in load-balanced fleets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,26 @@ Three layered base classes for data access:
 
 Connection key is configurable via the virtual `ConnectionKey` property or the `[ConnectionKey("Warehouse")]` attribute (resolved on the derived class).
 
+#### Sequence allocation (0.7.7)
+
+For document/invoice/order-number allocation that must stay distinct across concurrent callers, use `ISequenceProvider` instead of writing the locking dance by hand:
+
+```csharp
+[Scoped]
+public sealed class DocumentNumberService(ISequenceProvider sequences)
+{
+    public async Task<string> GetNextDocNoAsync(string docCode, CancellationToken ct = default)
+    {
+        var n = await sequences.NextAsync($"DocNo:{docCode}", ct);
+        return $"{docCode}-{n:00000}";
+    }
+}
+```
+
+Backed by a single `IdevsSequences` table the consumer creates in their migration pipeline (DDL in [MIGRATION.md](MIGRATION.md#v076--v077--isequenceprovider-helper)). Allocation is independent of any ambient `IUnitOfWork` by design — gaps in document numbers are normal, duplicates are catastrophic. `NextRangeAsync(key, count)` allocates a contiguous block atomically for bulk imports.
+
+`EnsureSequenceAsync(key, startValue: 1)` idempotently seeds a sequence row at app startup. Default registration is automatic via `[Scoped(ServiceType = typeof(ISequenceProvider))]`; manual DI hosts call `services.AddIdevsSequenceProvider()`.
+
 #### Concurrency primitives (0.7.6)
 
 For SELECT-then-UPDATE patterns that must stay atomic across concurrent callers — sequence allocation, balance transfers, queue consumers — two new primitives:
@@ -647,6 +667,7 @@ If the generator misbehaves on a specific build, set `<IdevsCoreLibUseSourceGene
 
 Detailed upgrade notes for every minor and major version live in [MIGRATION.md](MIGRATION.md). Latest transitions:
 
+- [v0.7.6 → v0.7.7 — ISequenceProvider helper](MIGRATION.md#v076--v077--isequenceprovider-helper)
 - [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](MIGRATION.md#v075--v076--row-lock-primitives--innewtransactionasync)
 - [v0.7.4 → v0.7.5 — CountAsync + ExistsAsync helpers](MIGRATION.md#v074--v075--countasync--existsasync-helpers)
 - [v0.7.3 → v0.7.4 — Explicit-fields Create/Update + NotMapped/Expression handling](MIGRATION.md#v073--v074--explicit-fields-createupdate--notmappedexpression-handling)

--- a/README.md
+++ b/README.md
@@ -211,8 +211,15 @@ Connection key is configurable via the virtual `ConnectionKey` property or the `
 For document/invoice/order-number allocation that must stay distinct across concurrent callers, use `ISequenceProvider` instead of writing the locking dance by hand:
 
 ```csharp
+public interface IDocumentNumberService
+{
+    Task<string> GetNextDocNoAsync(string docCode, CancellationToken ct = default);
+}
+
+// [Scoped] auto-registers via the I{ClassName} convention — the source
+// generator pairs DocumentNumberService with IDocumentNumberService.
 [Scoped]
-public sealed class DocumentNumberService(ISequenceProvider sequences)
+public sealed class DocumentNumberService(ISequenceProvider sequences) : IDocumentNumberService
 {
     public async Task<string> GetNextDocNoAsync(string docCode, CancellationToken ct = default)
     {

--- a/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
+++ b/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Autofac</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <Description>Optional Autofac integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
+++ b/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Idevs.Net.CoreLib.Generators.Abstractions</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <PackageTags>Idevs; CoreLib; Roslyn; SourceGenerator; Helpers</PackageTags>
     <Description>Reusable Roslyn helpers for source generators that integrate with Idevs.Net.CoreLib's DI conventions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
+++ b/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Serilog</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <Description>Optional Serilog integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/ISequenceProvider.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/ISequenceProvider.cs
@@ -1,0 +1,68 @@
+namespace Idevs.Repositories.Sequences;
+
+/// <summary>
+/// Atomic numeric sequence allocator. Each call returns a value that no
+/// other concurrent caller can return for the same <c>sequenceKey</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations MUST allocate independently of any ambient
+/// <see cref="Serenity.Data.IUnitOfWork"/> — the allocated value survives
+/// an outer caller's rollback. This is the intended semantic: gaps in the
+/// allocated range are normal (rolled-back outer transactions produce
+/// them), duplicate values are catastrophic. Document-number / invoice-
+/// number / order-number sequences are the canonical use case.
+/// </para>
+/// <para>
+/// Returned values are <see cref="long"/>; callers format to whatever
+/// scheme their domain requires (e.g. <c>INV-2026-00042</c>). The
+/// provider does not know about formatting.
+/// </para>
+/// </remarks>
+public interface ISequenceProvider
+{
+    /// <summary>
+    /// Allocate the next value for <paramref name="sequenceKey"/>.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// The sequence has not been seeded. Call
+    /// <see cref="EnsureSequenceAsync"/> first.
+    /// </exception>
+    /// <exception cref="System.ArgumentException">
+    /// <paramref name="sequenceKey"/> is null or empty.
+    /// </exception>
+    Task<long> NextAsync(string sequenceKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Allocate <paramref name="count"/> contiguous values atomically.
+    /// Returns them in ascending order. Useful for bulk imports where
+    /// every record needs an allocated number.
+    /// </summary>
+    /// <exception cref="System.InvalidOperationException">
+    /// The sequence has not been seeded.
+    /// </exception>
+    /// <exception cref="System.ArgumentException">
+    /// <paramref name="sequenceKey"/> is null or empty.
+    /// </exception>
+    /// <exception cref="System.ArgumentOutOfRangeException">
+    /// <paramref name="count"/> is not positive.
+    /// </exception>
+    Task<IReadOnlyList<long>> NextRangeAsync(
+        string sequenceKey, int count, CancellationToken ct = default);
+
+    /// <summary>
+    /// Idempotently create the sequence row with
+    /// <paramref name="startValue"/> as its first allocatable value.
+    /// If a row already exists for <paramref name="sequenceKey"/>, this
+    /// is a no-op — the existing <c>NextValue</c> is preserved
+    /// regardless of <paramref name="startValue"/>.
+    /// </summary>
+    /// <param name="sequenceKey">The sequence to seed.</param>
+    /// <param name="startValue">
+    /// First value <see cref="NextAsync"/> will return. Defaults to 1.
+    /// Ignored if the row already exists.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task EnsureSequenceAsync(
+        string sequenceKey, long startValue = 1, CancellationToken ct = default);
+}

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/IdevsSequenceRow.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/IdevsSequenceRow.cs
@@ -14,7 +14,11 @@ namespace Idevs.Repositories.Sequences;
 /// underlying <c>IdevsSequences</c> table in their own migration
 /// pipeline; the schema is documented in MIGRATION.md (v0.7.6 → v0.7.7).
 /// </remarks>
-[ConnectionKey("Default"), Module("Idevs"), TableName("[IdevsSequences]")]
+// TableName intentionally unquoted — Serenity applies dialect-appropriate
+// identifier quoting at SQL emission time. SqlServer brackets, MySQL
+// backticks, and Postgres double-quotes are all derived from the active
+// ISqlDialect; embedding "[…]" here would break MySQL/Postgres consumers.
+[ConnectionKey("Default"), Module("Idevs"), TableName("IdevsSequences")]
 public sealed class IdevsSequenceRow : Row<IdevsSequenceRow.RowFields>
 {
     /// <summary>

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/IdevsSequenceRow.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/IdevsSequenceRow.cs
@@ -1,0 +1,54 @@
+using Serenity.ComponentModel;
+using Serenity.Data;
+using Serenity.Data.Mapping;
+
+namespace Idevs.Repositories.Sequences;
+
+/// <summary>
+/// Persistent row backing <see cref="SqlSequenceProvider"/>. One row per
+/// distinct <c>SequenceKey</c>; <c>NextValue</c> holds the value the next
+/// <see cref="ISequenceProvider.NextAsync"/> call will return.
+/// </summary>
+/// <remarks>
+/// The library does not ship database migrations. Consumers create the
+/// underlying <c>IdevsSequences</c> table in their own migration
+/// pipeline; the schema is documented in MIGRATION.md (v0.7.6 → v0.7.7).
+/// </remarks>
+[ConnectionKey("Default"), Module("Idevs"), TableName("[IdevsSequences]")]
+public sealed class IdevsSequenceRow : Row<IdevsSequenceRow.RowFields>
+{
+    /// <summary>
+    /// Caller-defined sequence identifier. Convention: namespace with
+    /// colons (e.g. <c>"DocNo:SaleOrder"</c>, <c>"DocNo:Invoice:2026"</c>).
+    /// Primary key.
+    /// </summary>
+    [Size(100), NotNull, PrimaryKey]
+    public string? SequenceKey
+    {
+        get => fields.SequenceKey[this];
+        set => fields.SequenceKey[this] = value;
+    }
+
+    /// <summary>
+    /// The value the next <see cref="ISequenceProvider.NextAsync"/> call
+    /// will return for this sequence. After allocation, the row is
+    /// updated to <c>NextValue + 1</c> (or <c>+ count</c> for
+    /// <see cref="ISequenceProvider.NextRangeAsync"/>).
+    /// </summary>
+    [NotNull]
+    public long? NextValue
+    {
+        get => fields.NextValue[this];
+        set => fields.NextValue[this] = value;
+    }
+
+    public new static readonly RowFields Fields = (RowFields)new IdevsSequenceRow().GetFields();
+
+    public sealed class RowFields : RowFieldsBase
+    {
+#pragma warning disable CS8618 // populated by RowFieldsBase reflection
+        public StringField SequenceKey;
+        public Int64Field NextValue;
+#pragma warning restore CS8618
+    }
+}

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SequenceServiceCollectionExtensions.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SequenceServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Idevs.Repositories.Sequences;
+
+/// <summary>
+/// DI helpers for <see cref="ISequenceProvider"/>.
+/// </summary>
+/// <remarks>
+/// Source-generator-driven DI consumers don't need this — the
+/// <c>[Scoped]</c> attribute on <see cref="SqlSequenceProvider"/> is
+/// already picked up. This extension exists for manual setups (test
+/// hosts, console apps) where the source generator isn't running.
+/// </remarks>
+public static class SequenceServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register the SQL-backed default <see cref="ISequenceProvider"/>
+    /// as scoped. Call <see cref="ISequenceProvider.EnsureSequenceAsync"/>
+    /// (or seed via your migration pipeline) before allocating values.
+    /// </summary>
+    public static IServiceCollection AddIdevsSequenceProvider(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddScoped<ISequenceProvider, SqlSequenceProvider>();
+        return services;
+    }
+}

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SequenceUpsertBuilder.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SequenceUpsertBuilder.cs
@@ -1,0 +1,86 @@
+using Serenity.Data;
+
+namespace Idevs.Repositories.Sequences;
+
+/// <summary>
+/// Builds the dialect-specific "insert if not exists" statement used by
+/// <see cref="SqlSequenceProvider.EnsureSequenceAsync"/>. Internal — the
+/// generated SQL is paired with the well-known parameter names
+/// <c>@key</c> (string) and <c>@val</c> (long) the caller passes via
+/// <see cref="SqlServiceBase.ExecuteNonQueryAsync"/>.
+/// </summary>
+/// <remarks>
+/// The earlier "INSERT then catch on PK violation" approach broke on
+/// PostgreSQL: any error inside a transaction aborts it on PG, so the
+/// follow-up SELECT and the InNewTransactionAsync commit both fail with
+/// 25P02 ("current transaction is aborted, commands ignored until end
+/// of transaction block"). A single dialect-aware UPSERT side-steps the
+/// race and the abort, by never raising an error in the
+/// already-exists case.
+/// </remarks>
+internal static class SequenceUpsertBuilder
+{
+    /// <summary>
+    /// Returns a single SQL statement that inserts a row into
+    /// <c>IdevsSequences (SequenceKey, NextValue)</c> if no row exists
+    /// for <c>@key</c>, and is a no-op (no error) otherwise.
+    /// </summary>
+    /// <exception cref="System.NotSupportedException">
+    /// SQLite is fine, but anything outside the documented set
+    /// (SqlServer / MySQL / MariaDB / Postgres / Oracle / SQLite)
+    /// has no agreed upsert syntax. Throw so consumers know to either
+    /// pre-seed the row or extend this dispatch.
+    /// </exception>
+    public static string Build(ISqlDialect dialect)
+    {
+        ArgumentNullException.ThrowIfNull(dialect);
+
+        var serverType = dialect.ServerType ?? string.Empty;
+
+        // NOTE: identifiers are deliberately unquoted here — the
+        // schema documented in MIGRATION.md uses unquoted DDL on every
+        // engine, so case-folding on PostgreSQL is consistent. If a
+        // consumer quotes their CREATE TABLE differently, they'll need
+        // to override this provider with one that matches their schema.
+        if (IsSqlServer(serverType))
+            return "IF NOT EXISTS (SELECT 1 FROM IdevsSequences WHERE SequenceKey = @key) " +
+                   "INSERT INTO IdevsSequences (SequenceKey, NextValue) VALUES (@key, @val);";
+
+        if (IsMySql(serverType))
+            return "INSERT IGNORE INTO IdevsSequences (SequenceKey, NextValue) VALUES (@key, @val);";
+
+        if (IsPostgres(serverType))
+            return "INSERT INTO IdevsSequences (SequenceKey, NextValue) VALUES (@key, @val) " +
+                   "ON CONFLICT (SequenceKey) DO NOTHING;";
+
+        if (IsSqlite(serverType))
+            return "INSERT OR IGNORE INTO IdevsSequences (SequenceKey, NextValue) VALUES (@key, @val);";
+
+        // Oracle and other ANSI engines support MERGE; this is the most
+        // portable fallback. Fail loudly when we can't tell.
+        if (string.Equals(serverType, "Oracle", StringComparison.OrdinalIgnoreCase) ||
+            serverType.StartsWith("Oracle", StringComparison.OrdinalIgnoreCase))
+            return "MERGE INTO IdevsSequences t USING (SELECT @key AS K, @val AS V FROM dual) s " +
+                   "ON (t.SequenceKey = s.K) WHEN NOT MATCHED THEN " +
+                   "INSERT (SequenceKey, NextValue) VALUES (s.K, s.V)";
+
+        throw new NotSupportedException(
+            $"No documented insert-if-not-exists syntax for dialect '{serverType}'. " +
+            "Pre-seed the IdevsSequences row in your migration pipeline, or supply a " +
+            "custom ISequenceProvider implementation that knows your engine.");
+    }
+
+    private static bool IsSqlServer(string s) =>
+        s.Contains("SqlServer", StringComparison.OrdinalIgnoreCase) ||
+        s.Contains("MSSQL", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPostgres(string s) =>
+        s.Contains("Postgres", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsMySql(string s) =>
+        s.Contains("MySql", StringComparison.OrdinalIgnoreCase) ||
+        s.Contains("MariaDb", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSqlite(string s) =>
+        s.Contains("Sqlite", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SequenceUpsertBuilder.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SequenceUpsertBuilder.cs
@@ -43,8 +43,23 @@ internal static class SequenceUpsertBuilder
         // consumer quotes their CREATE TABLE differently, they'll need
         // to override this provider with one that matches their schema.
         if (IsSqlServer(serverType))
-            return "IF NOT EXISTS (SELECT 1 FROM IdevsSequences WHERE SequenceKey = @key) " +
-                   "INSERT INTO IdevsSequences (SequenceKey, NextValue) VALUES (@key, @val);";
+            // Atomic insert-if-not-exists with serializable-grade locking.
+            // The naive form `IF NOT EXISTS (SELECT ...) INSERT ...` is two
+            // statements and races under concurrency: two sessions can both
+            // see "no row", both attempt INSERT, the second hits a PK
+            // violation. The `INSERT ... SELECT ... WHERE NOT EXISTS`
+            // variant with WITH (UPDLOCK, HOLDLOCK) on the inner SELECT
+            // takes a key-range lock during the existence check that
+            // persists until the transaction commits — concurrent callers
+            // serialise on it and the second sees the row, so its WHERE
+            // NOT EXISTS evaluates false and the INSERT becomes a no-op.
+            // (We deliberately avoid MERGE: it has documented bugs across
+            // multiple SqlServer versions for race conditions and triggers.)
+            return "INSERT INTO IdevsSequences (SequenceKey, NextValue) " +
+                   "SELECT @key, @val " +
+                   "WHERE NOT EXISTS (" +
+                       "SELECT 1 FROM IdevsSequences WITH (UPDLOCK, HOLDLOCK) " +
+                       "WHERE SequenceKey = @key);";
 
         if (IsMySql(serverType))
             return "INSERT IGNORE INTO IdevsSequences (SequenceKey, NextValue) VALUES (@key, @val);";

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
@@ -1,0 +1,132 @@
+using Idevs.ComponentModels;
+using Serenity.Data;
+
+namespace Idevs.Repositories.Sequences;
+
+/// <summary>
+/// SQL-backed default <see cref="ISequenceProvider"/>. Stores one row per
+/// sequence in the <c>IdevsSequences</c> table; allocates values via
+/// <see cref="SqlServiceBase.InNewTransactionAsync{T}(System.Func{IUnitOfWork, System.Threading.CancellationToken, System.Threading.Tasks.Task{T}}, System.Threading.CancellationToken)"/>
+/// + <see cref="SqlQueryLockExtensions.ForUpdate"/> so the lock window is
+/// the duration of the SELECT…FOR UPDATE + UPDATE — typically
+/// sub-millisecond on a same-region database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered via <c>[Scoped(typeof(ISequenceProvider))]</c> for
+/// source-generator DI. Manual setups can call
+/// <see cref="SequenceServiceCollectionExtensions.AddIdevsSequenceProvider"/>.
+/// </para>
+/// <para>
+/// Defaults to <see cref="IdevsSequenceRow"/>'s <c>"Default"</c>
+/// connection key. To put sequences on a different connection, subclass
+/// <see cref="IdevsSequenceRow"/> with a different
+/// <c>[ConnectionKey]</c> attribute and supply a custom
+/// <see cref="ISequenceProvider"/> implementation against that subclass.
+/// </para>
+/// </remarks>
+[Scoped(ServiceType = typeof(ISequenceProvider))]
+public sealed class SqlSequenceProvider(ISqlConnections sqlConnections)
+    : RepositoryBase<IdevsSequenceRow>(sqlConnections), ISequenceProvider
+{
+    private static readonly IdevsSequenceRow.RowFields Fld = IdevsSequenceRow.Fields;
+
+    /// <inheritdoc />
+    public Task<long> NextAsync(string sequenceKey, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sequenceKey);
+
+        return InNewTransactionAsync(async (uow, token) =>
+        {
+            var row = await TryFirstAsync(
+                q => q.SelectTableFields()
+                      .Where(Fld.SequenceKey == sequenceKey)
+                      .ForUpdate(),
+                uow, token).ConfigureAwait(false)
+                ?? throw NotSeeded(sequenceKey);
+
+            var allocated = row.NextValue!.Value;
+            await UpdateAsync(
+                u => u.Set(Fld.NextValue, allocated + 1)
+                      .Where(Fld.SequenceKey == sequenceKey),
+                ExpectedRows.One, uow, token).ConfigureAwait(false);
+            return allocated;
+        }, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<long>> NextRangeAsync(
+        string sequenceKey, int count, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sequenceKey);
+        if (count <= 0)
+            throw new ArgumentOutOfRangeException(nameof(count),
+                "Range count must be a positive integer.");
+
+        return InNewTransactionAsync(async (uow, token) =>
+        {
+            var row = await TryFirstAsync(
+                q => q.SelectTableFields()
+                      .Where(Fld.SequenceKey == sequenceKey)
+                      .ForUpdate(),
+                uow, token).ConfigureAwait(false)
+                ?? throw NotSeeded(sequenceKey);
+
+            var first = row.NextValue!.Value;
+            await UpdateAsync(
+                u => u.Set(Fld.NextValue, first + count)
+                      .Where(Fld.SequenceKey == sequenceKey),
+                ExpectedRows.One, uow, token).ConfigureAwait(false);
+
+            var values = new long[count];
+            for (var i = 0; i < count; i++) values[i] = first + i;
+            return (IReadOnlyList<long>)values;
+        }, ct);
+    }
+
+    /// <inheritdoc />
+    public Task EnsureSequenceAsync(
+        string sequenceKey, long startValue = 1, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(sequenceKey);
+
+        return InNewTransactionAsync(async (uow, token) =>
+        {
+            // Plain TryFirstAsync (no ForUpdate) is fine here — concurrent
+            // EnsureSequenceAsync calls for the same key both see "no row",
+            // both attempt CreateAsync, the second hits the primary-key
+            // unique constraint and throws. Catching that path keeps the
+            // happy path free of the lock overhead. For a sequence that's
+            // about to be allocated against, the FIRST NextAsync will take
+            // the lock anyway; race here is irrelevant.
+            var existing = await TryFirstAsync(
+                q => q.SelectTableFields().Where(Fld.SequenceKey == sequenceKey),
+                uow, token).ConfigureAwait(false);
+            if (existing is not null) return;
+
+            try
+            {
+                await CreateAsync(new IdevsSequenceRow
+                {
+                    SequenceKey = sequenceKey,
+                    NextValue = startValue,
+                }, uow, token).ConfigureAwait(false);
+            }
+            catch
+            {
+                // If a concurrent EnsureSequenceAsync won the create race,
+                // re-check and treat the operation as a no-op. Anything
+                // else (DB unreachable, schema mismatch) propagates.
+                var racing = await TryFirstAsync(
+                    q => q.SelectTableFields().Where(Fld.SequenceKey == sequenceKey),
+                    uow, token).ConfigureAwait(false);
+                if (racing is null) throw;
+            }
+        }, ct);
+    }
+
+    private static InvalidOperationException NotSeeded(string sequenceKey) => new(
+        $"Sequence '{sequenceKey}' has not been seeded. " +
+        "Call ISequenceProvider.EnsureSequenceAsync first, or insert a row " +
+        "into IdevsSequences via your migration pipeline.");
+}

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Idevs.ComponentModels;
 using Serenity.Data;
 
@@ -13,8 +14,10 @@ namespace Idevs.Repositories.Sequences;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Registered via <c>[Scoped(typeof(ISequenceProvider))]</c> for
-/// source-generator DI. Manual setups can call
+/// Registered via <c>[Scoped(ServiceType = typeof(ISequenceProvider))]</c>
+/// for source-generator DI (the named-property form is required —
+/// <see cref="ScopedAttribute"/> has no positional constructor for the
+/// service type). Manual setups can call
 /// <see cref="SequenceServiceCollectionExtensions.AddIdevsSequenceProvider"/>.
 /// </para>
 /// <para>
@@ -112,11 +115,20 @@ public sealed class SqlSequenceProvider(ISqlConnections sqlConnections)
                     NextValue = startValue,
                 }, uow, token).ConfigureAwait(false);
             }
-            catch
+            catch (DbException)
             {
-                // If a concurrent EnsureSequenceAsync won the create race,
-                // re-check and treat the operation as a no-op. Anything
-                // else (DB unreachable, schema mismatch) propagates.
+                // Narrowed catch: only DbException (covers SqlException,
+                // MySqlException, NpgsqlException, etc.). Non-database
+                // errors — OperationCanceledException, ArgumentException,
+                // NullReferenceException — propagate without being
+                // inspected, so configuration / cancellation bugs surface
+                // immediately instead of being swallowed by the race
+                // recovery path.
+                //
+                // Re-check the row: if a concurrent EnsureSequenceAsync
+                // won the create race, treat as a no-op. Otherwise (e.g.
+                // permission error, schema missing, transient connection
+                // failure with no row yet) rethrow.
                 var racing = await TryFirstAsync(
                     q => q.SelectTableFields().Where(Fld.SequenceKey == sequenceKey),
                     uow, token).ConfigureAwait(false);

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
@@ -1,4 +1,3 @@
-using System.Data.Common;
 using Idevs.ComponentModels;
 using Serenity.Data;
 
@@ -49,8 +48,24 @@ public sealed class SqlSequenceProvider(ISqlConnections sqlConnections)
                 ?? throw NotSeeded(sequenceKey);
 
             var allocated = row.NextValue!.Value;
+
+            // Overflow protection: at long.MaxValue the unchecked `+ 1`
+            // would wrap to long.MinValue, producing negative allocations
+            // that would silently collide with future values once the
+            // counter wraps forward. We want loud failure, not silent
+            // corruption.
+            long advanced;
+            try { advanced = checked(allocated + 1); }
+            catch (OverflowException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Sequence '{sequenceKey}' has been exhausted: " +
+                    $"NextValue ({allocated}) is at long.MaxValue and cannot advance.",
+                    ex);
+            }
+
             await UpdateAsync(
-                u => u.Set(Fld.NextValue, allocated + 1)
+                u => u.Set(Fld.NextValue, advanced)
                       .Where(Fld.SequenceKey == sequenceKey),
                 ExpectedRows.One, uow, token).ConfigureAwait(false);
             return allocated;
@@ -76,8 +91,22 @@ public sealed class SqlSequenceProvider(ISqlConnections sqlConnections)
                 ?? throw NotSeeded(sequenceKey);
 
             var first = row.NextValue!.Value;
+
+            // Overflow protection — same reasoning as NextAsync but the
+            // jump is `+ count` instead of `+ 1`, so the threshold is
+            // closer to long.MaxValue.
+            long advanced;
+            try { advanced = checked(first + count); }
+            catch (OverflowException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Sequence '{sequenceKey}' would overflow: " +
+                    $"NextValue ({first}) + count ({count}) exceeds long.MaxValue.",
+                    ex);
+            }
+
             await UpdateAsync(
-                u => u.Set(Fld.NextValue, first + count)
+                u => u.Set(Fld.NextValue, advanced)
                       .Where(Fld.SequenceKey == sequenceKey),
                 ExpectedRows.One, uow, token).ConfigureAwait(false);
 
@@ -95,45 +124,20 @@ public sealed class SqlSequenceProvider(ISqlConnections sqlConnections)
 
         return InNewTransactionAsync(async (uow, token) =>
         {
-            // Plain TryFirstAsync (no ForUpdate) is fine here — concurrent
-            // EnsureSequenceAsync calls for the same key both see "no row",
-            // both attempt CreateAsync, the second hits the primary-key
-            // unique constraint and throws. Catching that path keeps the
-            // happy path free of the lock overhead. For a sequence that's
-            // about to be allocated against, the FIRST NextAsync will take
-            // the lock anyway; race here is irrelevant.
-            var existing = await TryFirstAsync(
-                q => q.SelectTableFields().Where(Fld.SequenceKey == sequenceKey),
-                uow, token).ConfigureAwait(false);
-            if (existing is not null) return;
-
-            try
+            // Single-statement dialect-aware UPSERT. No try/catch
+            // required: the statement is a no-op when the row already
+            // exists (no error, no transaction abort). This is the
+            // critical fix for PostgreSQL — the previous "INSERT then
+            // catch on PK violation" pattern aborted the surrounding
+            // transaction on PG (error 25P02), so the InNewTransactionAsync
+            // commit failed even when we'd correctly identified a race.
+            var sql = SequenceUpsertBuilder.Build(Dialect);
+            var parameters = new Dictionary<string, object?>
             {
-                await CreateAsync(new IdevsSequenceRow
-                {
-                    SequenceKey = sequenceKey,
-                    NextValue = startValue,
-                }, uow, token).ConfigureAwait(false);
-            }
-            catch (DbException)
-            {
-                // Narrowed catch: only DbException (covers SqlException,
-                // MySqlException, NpgsqlException, etc.). Non-database
-                // errors — OperationCanceledException, ArgumentException,
-                // NullReferenceException — propagate without being
-                // inspected, so configuration / cancellation bugs surface
-                // immediately instead of being swallowed by the race
-                // recovery path.
-                //
-                // Re-check the row: if a concurrent EnsureSequenceAsync
-                // won the create race, treat as a no-op. Otherwise (e.g.
-                // permission error, schema missing, transient connection
-                // failure with no row yet) rethrow.
-                var racing = await TryFirstAsync(
-                    q => q.SelectTableFields().Where(Fld.SequenceKey == sequenceKey),
-                    uow, token).ConfigureAwait(false);
-                if (racing is null) throw;
-            }
+                ["@key"] = sequenceKey,
+                ["@val"] = startValue,
+            };
+            await ExecuteNonQueryAsync(sql, parameters, uow, token).ConfigureAwait(false);
         }, ct);
     }
 

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
@@ -68,7 +68,8 @@ public sealed class MsSqlContainerFixture : IAsyncLifetime
 
         SqlConnections = new DefaultSqlConnections(defaultConnectionStrings);
 
-        // Create schema for the integration test row.
+        // Create schema for the integration test row + the IdevsSequences
+        // table the SqlSequenceProvider depends on.
         using var conn = SqlConnections.NewByKey("Default");
         SqlHelper.ExecuteNonQuery(conn, """
             IF OBJECT_ID('dbo.IntegrationTestRows', 'U') IS NOT NULL
@@ -80,7 +81,25 @@ public sealed class MsSqlContainerFixture : IAsyncLifetime
                 Amount DECIMAL(18,4) NOT NULL DEFAULT 0,
                 Status NVARCHAR(20) NULL
             );
+
+            IF OBJECT_ID('dbo.IdevsSequences', 'U') IS NOT NULL
+                DROP TABLE dbo.IdevsSequences;
+
+            CREATE TABLE dbo.IdevsSequences (
+                SequenceKey NVARCHAR(100) NOT NULL PRIMARY KEY,
+                NextValue BIGINT NOT NULL
+            );
             """);
+    }
+
+    /// <summary>
+    /// Truncate the IdevsSequences table — call between tests in
+    /// SqlSequenceProvider integration suites for isolation.
+    /// </summary>
+    public void TruncateSequencesTable()
+    {
+        using var conn = SqlConnections.NewByKey("Default");
+        SqlHelper.ExecuteNonQuery(conn, "TRUNCATE TABLE dbo.IdevsSequences;");
     }
 
     public async Task DisposeAsync()

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/SqlSequenceProviderTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/SqlSequenceProviderTests.cs
@@ -131,9 +131,14 @@ public sealed class SqlSequenceProviderTests : IDisposable
     [Fact]
     public async Task NextAsync_AtLongMaxValue_ThrowsExhaustionException()
     {
-        // Seed at long.MaxValue: the FIRST NextAsync should succeed
-        // (returning long.MaxValue) and try to advance to MaxValue + 1,
-        // which is the overflow point.
+        // Seeded at long.MaxValue. The implementation advances NextValue
+        // BEFORE returning the allocated value, so it tries
+        // checked(long.MaxValue + 1) and throws OverflowException, which
+        // we wrap as InvalidOperationException("...exhausted..."). The
+        // last value (long.MaxValue) is therefore unallocatable — a
+        // deliberate trade-off for safety: refusing the very last value
+        // is preferable to handing it out and silently corrupting the
+        // next call.
         await _sequences.EnsureSequenceAsync("DocNo:Overflow", startValue: long.MaxValue);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -175,6 +180,36 @@ public sealed class SqlSequenceProviderTests : IDisposable
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
             _sequences.NextRangeAsync("DoesNotExist", 5));
         Assert.Contains("EnsureSequenceAsync", ex.Message);
+    }
+
+    /// <summary>
+    /// 50 concurrent <see cref="ISequenceProvider.EnsureSequenceAsync"/>
+    /// calls for the same key, all racing on the initial INSERT. Pins
+    /// the SqlServer atomic-upsert pattern (INSERT … SELECT … WHERE
+    /// NOT EXISTS WITH (UPDLOCK, HOLDLOCK)). The naive
+    /// IF NOT EXISTS … INSERT shape would intermittently fail here
+    /// with a primary-key violation.
+    /// </summary>
+    [Fact]
+    public async Task FiftyConcurrentEnsureCalls_AllSucceed_OneRowExists()
+    {
+        const int n = 50;
+
+        var tasks = Enumerable.Range(0, n)
+            .Select(_ => _sequences.EnsureSequenceAsync("DocNo:EnsureRace", startValue: 100))
+            .ToArray();
+
+        // All 50 callers must succeed — no caller observes a PK conflict
+        // even though they all attempt to seed the same row simultaneously.
+        await Task.WhenAll(tasks);
+
+        // Exactly one row exists and the seeded value won.
+        var allocated = await _sequences.NextAsync("DocNo:EnsureRace");
+        Assert.Equal(100L, allocated);
+
+        // Subsequent NextAsync continues from 101 — proving the second
+        // EnsureSequenceAsync call did NOT overwrite NextValue.
+        Assert.Equal(101L, await _sequences.NextAsync("DocNo:EnsureRace"));
     }
 
     /// <summary>

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/SqlSequenceProviderTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/SqlSequenceProviderTests.cs
@@ -1,0 +1,202 @@
+using Idevs.Repositories.Sequences;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Integration coverage for <see cref="SqlSequenceProvider"/>: Ensure
+/// seeding semantics, NextAsync sequencing, NextRangeAsync atomic block
+/// allocation, and missing-key behavior. Concurrent allocation is
+/// covered by the dedicated test class so the underlying race is pinned
+/// at both the primitive (0.7.6) and helper (0.7.7) layers.
+/// </summary>
+[Collection(nameof(MsSqlContainerCollection))]
+[Trait("Category", "Integration")]
+public sealed class SqlSequenceProviderTests : IDisposable
+{
+    private readonly MsSqlContainerFixture _fixture;
+    private readonly SqlSequenceProvider _sequences;
+
+    public SqlSequenceProviderTests(MsSqlContainerFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.TruncateSequencesTable();
+        _sequences = new SqlSequenceProvider(fixture.SqlConnections);
+    }
+
+    public void Dispose() => _fixture.TruncateSequencesTable();
+
+    [Fact]
+    public async Task EnsureSequenceAsync_NewKey_CreatesRowWithStartValue()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Test", startValue: 1);
+
+        var first = await _sequences.NextAsync("DocNo:Test");
+        Assert.Equal(1L, first);
+    }
+
+    [Fact]
+    public async Task EnsureSequenceAsync_ExistingKey_PreservesNextValue()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Test", startValue: 1);
+        await _sequences.NextAsync("DocNo:Test"); // returns 1, NextValue is now 2
+        await _sequences.NextAsync("DocNo:Test"); // returns 2, NextValue is now 3
+
+        // Re-ensure with a different starting value — must NOT reset.
+        await _sequences.EnsureSequenceAsync("DocNo:Test", startValue: 999);
+
+        var next = await _sequences.NextAsync("DocNo:Test");
+        Assert.Equal(3L, next);
+    }
+
+    [Fact]
+    public async Task EnsureSequenceAsync_DefaultStartValueIsOne()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Default");
+        Assert.Equal(1L, await _sequences.NextAsync("DocNo:Default"));
+    }
+
+    [Fact]
+    public async Task EnsureSequenceAsync_CustomStartValue_UsedOnFirstNext()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Invoice2026", startValue: 1000);
+        Assert.Equal(1000L, await _sequences.NextAsync("DocNo:Invoice2026"));
+    }
+
+    [Fact]
+    public async Task NextAsync_ReturnsSequentialValues()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Seq", startValue: 10);
+
+        Assert.Equal(10L, await _sequences.NextAsync("DocNo:Seq"));
+        Assert.Equal(11L, await _sequences.NextAsync("DocNo:Seq"));
+        Assert.Equal(12L, await _sequences.NextAsync("DocNo:Seq"));
+    }
+
+    [Fact]
+    public async Task NextAsync_DifferentKeys_AreIndependent()
+    {
+        await _sequences.EnsureSequenceAsync("A", startValue: 1);
+        await _sequences.EnsureSequenceAsync("B", startValue: 100);
+
+        Assert.Equal(1L, await _sequences.NextAsync("A"));
+        Assert.Equal(100L, await _sequences.NextAsync("B"));
+        Assert.Equal(2L, await _sequences.NextAsync("A"));
+        Assert.Equal(101L, await _sequences.NextAsync("B"));
+    }
+
+    [Fact]
+    public async Task NextAsync_MissingKey_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sequences.NextAsync("DoesNotExist"));
+        Assert.Contains("EnsureSequenceAsync", ex.Message);
+    }
+
+    [Fact]
+    public async Task NextAsync_NullOrEmptyKey_Throws()
+    {
+        // ThrowIfNullOrEmpty throws ArgumentNullException for null and
+        // ArgumentException for empty — both derive from ArgumentException.
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => _sequences.NextAsync(null!));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => _sequences.NextAsync(""));
+    }
+
+    [Fact]
+    public async Task NextRangeAsync_AllocatesContiguousBlock()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Bulk", startValue: 1);
+
+        var range = await _sequences.NextRangeAsync("DocNo:Bulk", 5);
+
+        Assert.Equal(new long[] { 1, 2, 3, 4, 5 }, range);
+
+        // Subsequent NextAsync continues from 6 — the block was reserved.
+        Assert.Equal(6L, await _sequences.NextAsync("DocNo:Bulk"));
+    }
+
+    [Fact]
+    public async Task NextRangeAsync_LargeBlock_AdvancesNextValue()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Bulk2", startValue: 100);
+
+        var range = await _sequences.NextRangeAsync("DocNo:Bulk2", 1000);
+
+        Assert.Equal(1000, range.Count);
+        Assert.Equal(100L, range[0]);
+        Assert.Equal(1099L, range[^1]);
+        Assert.Equal(1100L, await _sequences.NextAsync("DocNo:Bulk2"));
+    }
+
+    [Fact]
+    public async Task NextRangeAsync_NonPositiveCount_Throws()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Bulk3");
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            _sequences.NextRangeAsync("DocNo:Bulk3", 0));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            _sequences.NextRangeAsync("DocNo:Bulk3", -1));
+    }
+
+    [Fact]
+    public async Task NextRangeAsync_MissingKey_Throws()
+    {
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sequences.NextRangeAsync("DoesNotExist", 5));
+        Assert.Contains("EnsureSequenceAsync", ex.Message);
+    }
+
+    /// <summary>
+    /// 50 concurrent allocators against the same sequence. Pins the race
+    /// fix at the higher level — duplicates would mean the underlying
+    /// 0.7.6 ForUpdate + InNewTransactionAsync isn't being used correctly.
+    /// </summary>
+    [Fact]
+    public async Task FiftyConcurrentAllocators_ProduceDistinctSequentialValues()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Concurrent", startValue: 1);
+
+        const int n = 50;
+        var tasks = Enumerable.Range(0, n)
+            .Select(_ => _sequences.NextAsync("DocNo:Concurrent"))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(n, results.Distinct().Count());
+        Assert.Equal(
+            Enumerable.Range(1, n).Select(i => (long)i).OrderBy(x => x),
+            results.OrderBy(x => x));
+    }
+
+    /// <summary>
+    /// Outer business transaction throws AFTER allocation. The allocated
+    /// number must remain (committed independently). This is the
+    /// deliberate trade-off — gaps in document numbers are normal,
+    /// duplicates are catastrophic.
+    /// </summary>
+    [Fact]
+    public async Task OuterRollback_DoesNotRollBackAllocatedValue()
+    {
+        await _sequences.EnsureSequenceAsync("DocNo:Outer", startValue: 1);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            using var conn = _fixture.SqlConnections.NewByKey("Default");
+            using var outerUow = new UnitOfWork(conn);
+
+            // Allocate inside an outer transaction that subsequently throws.
+            var allocated = await _sequences.NextAsync("DocNo:Outer");
+            Assert.Equal(1L, allocated);
+
+            throw new InvalidOperationException("simulate outer failure");
+            // outerUow disposes without Commit() -> outer state rolls back,
+            // but the sequence allocation is in its own transaction.
+        });
+
+        // The next allocation continues from 2, not 1 — proving the
+        // earlier allocation survived the outer rollback.
+        Assert.Equal(2L, await _sequences.NextAsync("DocNo:Outer"));
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/SqlSequenceProviderTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/SqlSequenceProviderTests.cs
@@ -129,6 +129,36 @@ public sealed class SqlSequenceProviderTests : IDisposable
     }
 
     [Fact]
+    public async Task NextAsync_AtLongMaxValue_ThrowsExhaustionException()
+    {
+        // Seed at long.MaxValue: the FIRST NextAsync should succeed
+        // (returning long.MaxValue) and try to advance to MaxValue + 1,
+        // which is the overflow point.
+        await _sequences.EnsureSequenceAsync("DocNo:Overflow", startValue: long.MaxValue);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sequences.NextAsync("DocNo:Overflow"));
+
+        Assert.Contains("exhausted", ex.Message);
+        Assert.Contains("long.MaxValue", ex.Message);
+        Assert.IsType<OverflowException>(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task NextRangeAsync_OverflowAtLongMaxValue_ThrowsExhaustionException()
+    {
+        // Seed near the boundary: (MaxValue - 5) + 10 overflows.
+        await _sequences.EnsureSequenceAsync("DocNo:OverflowRange", startValue: long.MaxValue - 5);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sequences.NextRangeAsync("DocNo:OverflowRange", 10));
+
+        Assert.Contains("overflow", ex.Message);
+        Assert.Contains("long.MaxValue", ex.Message);
+        Assert.IsType<OverflowException>(ex.InnerException);
+    }
+
+    [Fact]
     public async Task NextRangeAsync_NonPositiveCount_Throws()
     {
         await _sequences.EnsureSequenceAsync("DocNo:Bulk3");


### PR DESCRIPTION
## Summary

Higher-level helper built on 0.7.6's `ForUpdate()` + `InNewTransactionAsync` primitives. Replaces the SELECT-then-UPDATE boilerplate at the 37 document-number / invoice-number / order-number allocation sites with a single line:

```csharp
var n = await _sequences.NextAsync($"DocNo:{docCode}", ct);
```

The bug class that motivated 0.7.6 becomes unwriteable when consumers route through this API.

## Public surface

| API | Returns | Behaviour |
|---|---|---|
| `ISequenceProvider.NextAsync(string sequenceKey, ct)` | `Task<long>` | Allocate next value. Throws if not seeded. |
| `ISequenceProvider.NextRangeAsync(string sequenceKey, int count, ct)` | `Task<IReadOnlyList<long>>` | Allocate `count` contiguous values atomically. |
| `ISequenceProvider.EnsureSequenceAsync(string sequenceKey, long startValue = 1, ct)` | `Task` | Idempotently seed a sequence row. |
| `SequenceServiceCollectionExtensions.AddIdevsSequenceProvider()` | `IServiceCollection` | Manual DI registration. |

`SqlSequenceProvider` is the default impl, registered via `[Scoped(ServiceType = typeof(ISequenceProvider))]`. Storage is a single `IdevsSequences` table (`SequenceKey NVARCHAR(100) PRIMARY KEY`, `NextValue BIGINT NOT NULL`). Consumers create the table in their migration pipeline — DDL for SqlServer / MySQL / Postgres in `MIGRATION.md`.

## Design intent

- **No `IUnitOfWork` parameter on the interface.** Allocation is fundamentally a "must commit independently" operation — letting callers pass a UoW invites recreating the original race. The contract refuses the option.
- **Returns `long`.** Library doesn't know your format scheme (`INV-2026-00042`, `SO/2026/00001`). Caller formats.
- **`NextRangeAsync` shipped from day one.** Bulk imports need it; bolting it on later means changing both interface and implementation.
- **Independent commit semantics, documented loudly.** Allocated value survives outer-caller rollback. For document numbers that's correct (gaps are normal, duplicates are catastrophic). For anything where the inner allocation must roll back with the outer flow, do NOT use this — implement directly.

## Caller migration

Before (0.7.6 — primitives wired by hand):
```csharp
public Task<string> GetNextDocNoAsync(string docCode, CancellationToken ct = default) =>
    InNewTransactionAsync(async (uow, token) =>
    {
        var row = await TryFirstAsync(
            q => q.SelectTableFields().Where(...).ForUpdate(), uow, token);
        if (row is null) throw ...;
        row.NextDocumentNo += 1;
        await UpdateAsync(row, uow, token);
        return Format(docCode, row.NextDocumentNo!.Value);
    }, ct);
```

After (0.7.7):
```csharp
public async Task<string> GetNextDocNoAsync(string docCode, CancellationToken ct = default)
{
    var n = await _sequences.NextAsync($"DocNo:{docCode}", ct);
    return Format(docCode, n);
}
```

## Test plan

- [x] 14 integration tests in `SqlSequenceProviderTests` (Testcontainers MSSQL 2022): ensure semantics, NextAsync sequencing + per-key isolation, argument validation, NextRangeAsync block allocation incl. 1000-row block, **50 concurrent allocators produce 50 distinct values** (the underlying race fix re-pinned at the helper level), **outer-rollback does not roll back the allocated value**.
- [x] Full library suite: **207 passed, 1 documented skip, 0 failures** on net8.0.
- [x] Release build produces `0.7.7.nupkg` for all four packable projects: `Idevs.Net.CoreLib`, `Idevs.Net.CoreLib.Autofac`, `Idevs.Net.CoreLib.Generators.Abstractions`, `Idevs.Net.CoreLib.Serilog`.
- [ ] Verify against MySQL / Postgres in production deployments before broad rollout.

## Docs

- `CHANGELOG.md` — full 0.7.7 entry covering the API surface, the design rationale, and what was verified.
- `MIGRATION.md` — new v0.7.6 → v0.7.7 section with schema DDL for SqlServer / MySQL / Postgres, a before/after caller-migration example, seeding patterns, sequence-key naming convention, and four documented caveats (independent commit semantics, connection pool sizing, no bulk-insert wiring, concurrent EnsureSequenceAsync race).
- `README.md` — new "Sequence allocation (0.7.7)" subsection under Repositories with a worked example, plus updated migration link list.

## Out of scope (future releases)

- Native database sequences (`CREATE SEQUENCE` on Postgres / SqlServer 2012+ / MariaDB 10.3+) — different shape; bypass the row-lock entirely. Will land as a sibling `DatabaseSequenceProvider : ISequenceProvider` in 0.8.0+.
- HiLo / batched-allocation provider for very high concurrency. 0.9.0+.
- IDEVS006 analyzer that points the codefix at `ISequenceProvider.NextAsync` — slot 0.8.0 alongside the rest of the analyzer track.