### PR TITLE
feat: add optimistic concurrency on UpdateAsync (0.7.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## 0.7.8 (2026-05-08)
+
+### Added
+
+- `Idevs.Repositories.RowVersionAttribute` — opt-in marker for a
+  `long?` property that the library uses as the row's
+  optimistic-concurrency version counter. Apply once per row.
+- `Idevs.Repositories.OptimisticConcurrencyException` — thrown when a
+  guarded UPDATE affects zero rows. Carries `TableName`, `RowId`, and
+  `CapturedVersion` for diagnostics; intentionally does not carry the
+  current database version (re-reading the row is the only safe path
+  to recovery, exposing the current value here would invite naive
+  retries).
+
+### Changed
+
+- `RepositoryBase<TRow,TKey>.UpdateAsync(TRow row, …)` now detects a
+  `[RowVersion]` field on the row type. When present, the SQL gains
+  `WHERE RowVersion = @captured` and `SET RowVersion = RowVersion + 1`,
+  the call runs with `ExpectedRows.Ignore`, and 0 affected rows
+  becomes `OptimisticConcurrencyException`. After a successful update,
+  the new version is written back to the row instance so the caller
+  can reuse it for further updates without re-reading.
+- `UpdateAsync(TRow row, Field[] fields, …)` and
+  `UpdateExcludingAsync(TRow row, Field[] excludeFields, …)` apply the
+  same guard — opting out of RowVersion via field selection is not
+  possible by design (optimistic concurrency is non-negotiable for
+  versioned rows).
+- Rows without `[RowVersion]` are unchanged from 0.7.7 — no WHERE
+  clause added, no exception type changes, identical behaviour.
+
+### Validation (fail-loud at first lookup, cached forever)
+
+- More than one `[RowVersion]` property on a row throws
+  `InvalidOperationException` with the offending property names.
+- `[RowVersion]` on a non-`long?` property throws with a type-mismatch
+  message pointing at the right shape.
+- `[RowVersion]` property without a matching `Int64Field` in
+  `RowFields` throws with the exact field declaration the consumer
+  needs to add.
+- A `[RowVersion]` field with `FieldFlags.Updatable` cleared throws —
+  the library increments it on every guarded UPDATE, so making it
+  non-Updatable would silently disable the guard.
+- `null` `RowVersion` value at update time throws — the captured
+  version must be known, which means the caller must read the row
+  before updating. Catches "constructed by hand" bugs early.
+
+### Verified (xUnit + Testcontainers vs SQL Server 2022)
+
+- 8 integration tests in `OptimisticConcurrencyTests` cover: happy
+  path increment via all three TRow-shaped UpdateAsync overloads;
+  conflict detection on stale RowVersion (single-conflict + 50-way
+  stampede); manual retry pattern (5 concurrent +1 increments
+  resolved via re-read loop); precondition checks (null RowVersion);
+  non-versioned regression sanity test (rows without `[RowVersion]`
+  unchanged).
+
+### Notes
+
+- **No built-in retry helper.** Optimistic concurrency is a
+  policy-level concern (how many retries, how long to wait, what
+  conflicts mean for the business). Document the manual try/retry
+  pattern; revisit if real demand emerges. See MIGRATION.md (v0.7.7 →
+  v0.7.8) for the canonical retry shape.
+- **Application-managed `BIGINT`, not native `rowversion`.** The
+  schema is portable across SqlServer / MySQL / MariaDB / PostgreSQL
+  / Oracle / SQLite — a plain `BIGINT NOT NULL DEFAULT 0`. SqlServer's
+  native `rowversion` / `timestamp` type isn't used because it's
+  `varbinary(8)`, not portable, and a `bigint` counter has plenty of
+  range for any realistic workload.
+- **Criteria-based `UpdateAsync(Action<SqlUpdate>, …)` is unchanged.**
+  The caller owns the WHERE clause in that overload — adding magic
+  guards would surprise. Add the `WHERE RowVersion = ...` manually if
+  needed.
+
 ## 0.7.7 (2026-05-07)
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 
 ## Contents
 
+- [v0.7.7 → v0.7.8 — Optimistic concurrency on UpdateAsync](#v077--v078--optimistic-concurrency-on-updateasync)
 - [v0.7.6 → v0.7.7 — ISequenceProvider helper](#v076--v077--isequenceprovider-helper)
 - [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](#v075--v076--row-lock-primitives--innewtransactionasync)
 - [v0.7.4 → v0.7.5 — CountAsync + ExistsAsync helpers](#v074--v075--countasync--existsasync-helpers)
@@ -15,6 +16,183 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 - [v0.3.x → v0.5.0 — Package Layout & DI Changes](#v03x--v050--package-layout--di-changes)
 - [v0.1.x → v0.2.0 — Autofac Integration](#v01x--v020--autofac-integration)
 - [v0.0.x → v0.1.x — Service Registration & Chrome Setup](#v00x--v01x--service-registration--chrome-setup)
+
+---
+
+## v0.7.7 → v0.7.8 — Optimistic concurrency on UpdateAsync
+
+### What changed
+
+Two additive types and a behavioural opt-in:
+
+| API | Returns / role |
+|---|---|
+| `[RowVersion]` attribute | Marker on a `long?` property; flags the row's version column. |
+| `OptimisticConcurrencyException` | Thrown by `UpdateAsync` when a guarded UPDATE affects 0 rows. Carries `TableName`, `RowId`, `CapturedVersion`. |
+
+When a row carries `[RowVersion]`, the three TRow-shaped UpdateAsync
+overloads on `RepositoryBase<TRow, TKey>` automatically apply the
+optimistic-concurrency guard:
+
+1. Capture the row's current `RowVersion` value.
+2. Add `WHERE RowVersion = @captured` to the UPDATE.
+3. Add `SET RowVersion = RowVersion + 1` to the SET list.
+4. Run with `ExpectedRows.Ignore` (we manually check affected count).
+5. If affected rows == 0, throw `OptimisticConcurrencyException`.
+6. Otherwise, write `captured + 1` back to `row.RowVersion` so the
+   caller can reuse the row for further updates without re-reading.
+
+Rows without `[RowVersion]` see zero behaviour change. The
+criteria-based `UpdateAsync(Action<SqlUpdate>, …)` overload on
+`RepositoryBase<TRow>` is also unchanged — that overload takes an
+arbitrary builder where the caller owns the WHERE.
+
+### Caller-side example
+
+```csharp
+public sealed class OrderRow : Row<OrderRow.RowFields>, IIdRow
+{
+    [Identity, IdProperty]
+    public int? Id { get => fields.Id[this]; set => fields.Id[this] = value; }
+
+    [Size(50), NotNull]
+    public string? CustomerCode
+    {
+        get => fields.CustomerCode[this];
+        set => fields.CustomerCode[this] = value;
+    }
+
+    [NotNull, RowVersion]                              // <-- one attribute
+    public long? RowVersion
+    {
+        get => fields.RowVersion[this];
+        set => fields.RowVersion[this] = value;
+    }
+
+    public sealed class RowFields : RowFieldsBase
+    {
+        public Int32Field Id;
+        public StringField CustomerCode;
+        public Int64Field RowVersion;
+    }
+}
+
+// Caller code — same shape as before, with one extra catch:
+var order = await repo.GetByIdAsync(orderId);
+order.CustomerCode = newCode;
+try
+{
+    await repo.UpdateAsync(order);
+}
+catch (OptimisticConcurrencyException)
+{
+    // Stale write. Re-read, re-apply, retry — pattern is consumer's choice.
+}
+```
+
+### Schema
+
+Application-managed `BIGINT`, portable across all supported engines.
+Add to existing tables that need optimistic concurrency:
+
+#### SqlServer
+
+```sql
+ALTER TABLE Orders ADD RowVersion BIGINT NOT NULL DEFAULT 0;
+```
+
+#### MySQL / MariaDB
+
+```sql
+ALTER TABLE Orders ADD COLUMN RowVersion BIGINT NOT NULL DEFAULT 0;
+```
+
+#### PostgreSQL
+
+```sql
+ALTER TABLE Orders ADD COLUMN RowVersion BIGINT NOT NULL DEFAULT 0;
+```
+
+The library does not use SqlServer's native `rowversion` / `timestamp`
+type. Reasons: not portable (`varbinary(8)` only exists on SqlServer),
+changes the field type story (would need `byte[]?` instead of `long?`),
+and a 64-bit application-managed counter has more than enough range
+(at one increment per nanosecond it would take ~292 years to exhaust).
+
+### The retry pattern
+
+The library does not ship a built-in retry helper — number of retries,
+backoff, and "what should the user see when retries fail" are all
+policy decisions. Use the standard manual shape:
+
+```csharp
+async Task<int> UpdateWithRetryAsync(int orderId, Action<OrderRow> mutate, int maxAttempts = 3)
+{
+    for (var attempt = 1; attempt <= maxAttempts; attempt++)
+    {
+        var order = await _repo.GetByIdAsync(orderId);
+        mutate(order);
+        try
+        {
+            await _repo.UpdateAsync(order);
+            return order.RowVersion!.Value;
+        }
+        catch (OptimisticConcurrencyException) when (attempt < maxAttempts)
+        {
+            // Re-read on next iteration. Polly callers can also catch
+            // OptimisticConcurrencyException and apply their own policy.
+        }
+    }
+
+    throw new OptimisticConcurrencyException(
+        tableName: "Orders", rowId: orderId, capturedVersion: -1);
+}
+```
+
+A built-in `RetryOnConcurrencyConflictAsync` may land in 0.8.0+ if
+real demand emerges; for now, document the manual pattern.
+
+### Validation — the library fails loud on misuse
+
+These all throw `InvalidOperationException` at the first guarded
+UPDATE call (and the result is cached so subsequent calls don't pay
+the reflection cost):
+
+| Misuse | Error |
+|---|---|
+| Two properties carry `[RowVersion]` | "Row type 'X' has 2 [RowVersion] properties (A, B); expected at most one." |
+| `[RowVersion]` on a non-`long?` property | "Property 'X.A' must be of type 'long?'; got 'int?'. Use `public long? A { get; set; }` …" |
+| `[RowVersion]` property has no matching `Field` in `RowFields` | "Property 'X.A' has no matching Field in RowFields. Add `public Int64Field A;` …" |
+| `[RowVersion]` field has `Updatable` flag cleared | "Field 'X.A' is not Updatable. The library increments this field on every guarded UPDATE; clearing the Updatable flag would prevent that." |
+| `row.RowVersion` is `null` at update time | "RowVersion is null on the row passed to UpdateAsync. Read the row before updating — null means the captured version is unknown." |
+
+The last one catches "constructed by hand" bugs early. If a caller
+populates a row from a cache or maps from a DTO without setting
+`RowVersion`, the call fails with a clear message instead of silently
+running an unguarded UPDATE.
+
+### Important caveats
+
+- **The criteria-based `UpdateAsync(Action<SqlUpdate>, …)` overload on
+  `RepositoryBase<TRow>` is NOT guarded.** If you use that overload on
+  a versioned row, you own the `WHERE RowVersion = …` clause. Add
+  it manually or use the row-shaped overloads.
+- **Backfill `RowVersion` on existing tables.** When you add the
+  column to existing tables with the DDL above, the `DEFAULT 0` fills
+  in for existing rows — they all get version 0. The first update on
+  any of those rows captures 0 and advances to 1. No data migration
+  needed.
+- **Reflection, but cached.** `[RowVersion]` is detected via
+  reflection at first lookup per row type, then cached as a `Field`
+  reference in a `ConcurrentDictionary<Type, Field?>`. Steady-state
+  cost is one dictionary read per UPDATE.
+- **No interference with `ISequenceProvider`.** Sequence rows
+  (`IdevsSequenceRow`) don't carry `[RowVersion]` and won't pick up
+  the guard. The two features are independent.
+- **`CreateAsync` doesn't set RowVersion.** Leave the property `null`
+  on the row instance you pass to `CreateAsync`; the database default
+  (`0`) takes over. Subsequent UpdateAsync calls capture 0 and
+  advance from there.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,41 @@ Three layered base classes for data access:
 
 Connection key is configurable via the virtual `ConnectionKey` property or the `[ConnectionKey("Warehouse")]` attribute (resolved on the derived class).
 
+#### Optimistic concurrency (0.7.8)
+
+Mark a `long?` property with `[RowVersion]` and the three TRow-shaped `UpdateAsync` overloads on `RepositoryBase<TRow, TKey>` automatically guard the UPDATE with `WHERE RowVersion = @captured` and `SET RowVersion = RowVersion + 1`. On a stale write the library throws `OptimisticConcurrencyException` carrying `TableName`, `RowId`, and `CapturedVersion`:
+
+```csharp
+public sealed class OrderRow : Row<OrderRow.RowFields>, IIdRow
+{
+    [Identity, IdProperty]
+    public int? Id { get => fields.Id[this]; set => fields.Id[this] = value; }
+
+    [Size(50), NotNull]
+    public string? CustomerCode { get => fields.CustomerCode[this]; set => fields.CustomerCode[this] = value; }
+
+    [NotNull, RowVersion]                      // <-- one attribute
+    public long? RowVersion { get => fields.RowVersion[this]; set => fields.RowVersion[this] = value; }
+
+    public sealed class RowFields : RowFieldsBase
+    {
+        public Int32Field Id;
+        public StringField CustomerCode;
+        public Int64Field RowVersion;
+    }
+}
+
+// Caller code:
+var order = await repo.GetByIdAsync(orderId);
+order.CustomerCode = newCode;
+try { await repo.UpdateAsync(order); }                         // RowVersion advances 0 → 1
+catch (OptimisticConcurrencyException) { /* re-read, retry */ }
+```
+
+Schema-side: a plain `BIGINT NOT NULL DEFAULT 0` column. Portable across SqlServer, MySQL/MariaDB, PostgreSQL, Oracle, SQLite. Adding it to an existing table backfills as version 0 — no data migration needed.
+
+Rows without `[RowVersion]` see no behaviour change. The criteria-based `UpdateAsync(Action<SqlUpdate>, …)` overload is unchanged — caller owns the WHERE there. See [MIGRATION.md](MIGRATION.md#v077--v078--optimistic-concurrency-on-updateasync) for the manual retry pattern, validation rules, and full schema DDL by engine.
+
 #### Sequence allocation (0.7.7)
 
 For document/invoice/order-number allocation that must stay distinct across concurrent callers, use `ISequenceProvider` instead of writing the locking dance by hand:
@@ -674,6 +709,7 @@ If the generator misbehaves on a specific build, set `<IdevsCoreLibUseSourceGene
 
 Detailed upgrade notes for every minor and major version live in [MIGRATION.md](MIGRATION.md). Latest transitions:
 
+- [v0.7.7 → v0.7.8 — Optimistic concurrency on UpdateAsync](MIGRATION.md#v077--v078--optimistic-concurrency-on-updateasync)
 - [v0.7.6 → v0.7.7 — ISequenceProvider helper](MIGRATION.md#v076--v077--isequenceprovider-helper)
 - [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](MIGRATION.md#v075--v076--row-lock-primitives--innewtransactionasync)
 - [v0.7.4 → v0.7.5 — CountAsync + ExistsAsync helpers](MIGRATION.md#v074--v075--countasync--existsasync-helpers)

--- a/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
+++ b/src/Idevs.Net.CoreLib.Autofac/Idevs.Net.CoreLib.Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Autofac</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <Description>Optional Autofac integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
+++ b/src/Idevs.Net.CoreLib.Generators.Abstractions/Idevs.Net.CoreLib.Generators.Abstractions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Idevs.Net.CoreLib.Generators.Abstractions</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <PackageTags>Idevs; CoreLib; Roslyn; SourceGenerator; Helpers</PackageTags>
     <Description>Reusable Roslyn helpers for source generators that integrate with Idevs.Net.CoreLib's DI conventions.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
+++ b/src/Idevs.Net.CoreLib.Serilog/Idevs.Net.CoreLib.Serilog.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib.Serilog</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <Description>Optional Serilog integration for Idevs.Net.CoreLib.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -35,3 +35,10 @@ Idevs.Repositories.SqlServiceBase.ExecuteScalarAsync<T>(string sql, System.Colle
 Idevs.Repositories.SqlServiceBase.ExecuteNonQueryAsync(string sql, System.Collections.Generic.IDictionary<string, object> parameters = null, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
 Idevs.Repositories.SqlServiceBase.ExecuteScalar<T>(string sql, System.Collections.Generic.IDictionary<string, object> parameters = null, Serenity.Data.IUnitOfWork uow = null) -> T
 Idevs.Repositories.SqlServiceBase.ExecuteNonQuery(string sql, System.Collections.Generic.IDictionary<string, object> parameters = null, Serenity.Data.IUnitOfWork uow = null) -> int
+Idevs.Repositories.RowVersionAttribute
+Idevs.Repositories.RowVersionAttribute.RowVersionAttribute() -> void
+Idevs.Repositories.OptimisticConcurrencyException
+Idevs.Repositories.OptimisticConcurrencyException.OptimisticConcurrencyException(string tableName, object rowId, long capturedVersion) -> void
+Idevs.Repositories.OptimisticConcurrencyException.TableName.get -> string
+Idevs.Repositories.OptimisticConcurrencyException.RowId.get -> object
+Idevs.Repositories.OptimisticConcurrencyException.CapturedVersion.get -> long

--- a/src/Idevs.Net.CoreLib/Repositories/OptimisticConcurrencyException.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/OptimisticConcurrencyException.cs
@@ -1,0 +1,54 @@
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Thrown when an UPDATE guarded by a <see cref="RowVersionAttribute"/>
+/// field affects zero rows — meaning another caller modified the row
+/// after this caller read it. Callers handle this by re-reading the
+/// row, re-applying their change, and retrying the UPDATE.
+/// </summary>
+/// <remarks>
+/// Carries enough context to log or surface a useful error: the table
+/// name, the row's primary-key value, and the version the failing
+/// caller had captured. The actual database row's current
+/// <c>RowVersion</c> is intentionally NOT carried — re-reading the row
+/// is the only safe way to recover, and exposing the current version
+/// here would invite consumers to "retry with this value" without
+/// re-reading dependent fields.
+/// </remarks>
+public sealed class OptimisticConcurrencyException : Exception
+{
+    /// <summary>
+    /// Construct a conflict exception with the contextual fields the
+    /// library can report from inside an UPDATE guard.
+    /// </summary>
+    public OptimisticConcurrencyException(string tableName, object? rowId, long capturedVersion)
+        : base(BuildMessage(tableName, rowId, capturedVersion))
+    {
+        TableName = tableName;
+        RowId = rowId;
+        CapturedVersion = capturedVersion;
+    }
+
+    /// <summary>The name of the table whose UPDATE was guarded.</summary>
+    public string TableName { get; }
+
+    /// <summary>
+    /// The primary-key value of the row the caller tried to update.
+    /// May be <c>null</c> only in the unusual case of a row type without
+    /// an Id — in practice always set.
+    /// </summary>
+    public object? RowId { get; }
+
+    /// <summary>
+    /// The <c>RowVersion</c> value the caller had captured when they
+    /// read the row. The current database value is higher; re-read the
+    /// row to find out by how much.
+    /// </summary>
+    public long CapturedVersion { get; }
+
+    private static string BuildMessage(string tableName, object? rowId, long capturedVersion) =>
+        $"Optimistic concurrency conflict on '{tableName}' " +
+        $"(id={rowId ?? "<null>"}, captured RowVersion={capturedVersion}). " +
+        "The row was modified by another caller since it was read. " +
+        "Re-read the row, re-apply your changes, and retry the UPDATE.";
+}

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
@@ -127,18 +127,32 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
                 "unknown, which would silently disable the optimistic-concurrency guard.");
         var captured = Convert.ToInt64(capturedObj);
 
+        // Compute the next version once, with overflow protection. Throwing
+        // here is preferable to silently wrapping past long.MaxValue and
+        // producing negative/colliding versions on the next allocator.
+        long nextVersion;
+        try { nextVersion = checked(captured + 1); }
+        catch (OverflowException ex)
+        {
+            throw new InvalidOperationException(
+                $"[RowVersion] field '{row.Table}.{rvField.Name}' is at long.MaxValue " +
+                $"({captured}) and cannot advance. The row is at the end of its version " +
+                "space; the table or row needs to be migrated to reset the counter.", ex);
+        }
+
         return ExecuteAsync((c, _) =>
         {
             var update = SqlUpdate(row.Table);
 
             // Build the SET list per the caller's field-selection rules.
-            // The RowVersion field is always set to `captured + 1` regardless,
-            // so an explicit-fields list that omits it is fine.
+            // RowVersion is set explicitly below to `nextVersion`, so callers
+            // who pass it in `fieldsToSet` (or omit it from `excludeFields`)
+            // don't get their value used — the guard always wins.
             if (fieldsToSet is not null)
             {
                 foreach (var f in fieldsToSet)
                 {
-                    if (ReferenceEquals(f, rvField)) continue; // we'll set it below
+                    if (ReferenceEquals(f, rvField)) continue; // set below
                     update.Set(f, f.AsObject(row));
                 }
             }
@@ -147,7 +161,7 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
                 foreach (var f in row.GetFields())
                 {
                     if (ReferenceEquals(f, idField)) continue;
-                    if (ReferenceEquals(f, rvField)) continue; // we'll set it below
+                    if (ReferenceEquals(f, rvField)) continue; // set below
                     if (excludeFields is not null && excludeFields.Contains(f)) continue;
                     if (!row.IsAssigned(f)) continue;
                     if ((f.Flags & FieldFlags.NotMapped) != 0) continue;
@@ -156,7 +170,13 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
                 }
             }
 
-            update.Set(rvField, captured + 1);
+            // SET RowVersion = @nextVersion (an app-computed constant).
+            // Equivalent to SET RowVersion = RowVersion + 1 because the WHERE
+            // clause below pins RowVersion to `captured`, so the matched row's
+            // current version + 1 IS nextVersion. The constant form is simpler
+            // and lets us write the value back to the row instance after the
+            // call without an extra round-trip.
+            update.Set(rvField, nextVersion);
 
             update.Where(new BinaryCriteria(
                 new Criteria(idField),
@@ -176,7 +196,7 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
 
             // Row stayed put. Write the new RowVersion back so the caller can
             // reuse the same instance for further updates without re-reading.
-            rvField.AsObject(row, (object?)(captured + 1));
+            rvField.AsObject(row, (object?)nextVersion);
             return Task.FromResult(true);
         }, uow, ct);
     }

--- a/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RepositoryBaseTKey.cs
@@ -71,10 +71,113 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
     {
         ArgumentNullException.ThrowIfNull(row);
 
+        var rvField = RowVersionMetadata.Find(row);
+        if (rvField is null)
+        {
+            // No [RowVersion] field — preserve today's behaviour exactly.
+            return ExecuteAsync((c, _) =>
+            {
+                var affected = c.UpdateById(row);
+                return Task.FromResult(affected > 0);
+            }, uow, ct);
+        }
+
+        // [RowVersion] guarded path: assemble the SqlUpdate ourselves so we
+        // can inject SET RowVersion = RowVersion + 1 and WHERE RowVersion = @captured,
+        // run with ExpectedRows.Ignore (we'll check affected ourselves), and
+        // throw OptimisticConcurrencyException on conflict.
+        return UpdateGuardedAsync(row, rvField, fieldsToSet: null, excludeFields: null, uow, ct);
+    }
+
+    /// <summary>
+    /// Shared write path used by all three TRow-shaped UpdateAsync overloads
+    /// when the row carries a <see cref="RowVersionAttribute"/> field. Builds
+    /// a SqlUpdate, applies the caller's field-selection rules, layers the
+    /// RowVersion guard on top, and translates affected-rows == 0 into
+    /// <see cref="OptimisticConcurrencyException"/>.
+    /// </summary>
+    /// <remarks>
+    /// <c>fieldsToSet</c>: when non-null, only these fields go into SET
+    /// (used by the explicit-fields overload). When null, all
+    /// assigned/Updatable fields are included.
+    /// <c>excludeFields</c>: when non-null, these fields are excluded
+    /// from SET (used by UpdateExcludingAsync). Ignored when
+    /// <c>fieldsToSet</c> is non-null.
+    /// </remarks>
+    private Task<bool> UpdateGuardedAsync(
+        TRow row,
+        Field rvField,
+        Field[]? fieldsToSet,
+        HashSet<Field>? excludeFields,
+        IUnitOfWork? uow,
+        CancellationToken ct)
+    {
+        var idRow = (IIdRow)row;
+        var idField = idRow.IdField;
+        var idValue = idField.AsObject(row);
+        if (idValue is null)
+            throw new InvalidOperationException(
+                "Row's Id must be set before calling UpdateAsync on a [RowVersion]-guarded row.");
+
+        var capturedObj = rvField.AsObject(row);
+        if (capturedObj is null)
+            throw new InvalidOperationException(
+                $"[RowVersion] field '{row.Table}.{rvField.Name}' is null on the row passed to " +
+                "UpdateAsync. Read the row before updating — null means the captured version is " +
+                "unknown, which would silently disable the optimistic-concurrency guard.");
+        var captured = Convert.ToInt64(capturedObj);
+
         return ExecuteAsync((c, _) =>
         {
-            var affected = c.UpdateById(row);
-            return Task.FromResult(affected > 0);
+            var update = SqlUpdate(row.Table);
+
+            // Build the SET list per the caller's field-selection rules.
+            // The RowVersion field is always set to `captured + 1` regardless,
+            // so an explicit-fields list that omits it is fine.
+            if (fieldsToSet is not null)
+            {
+                foreach (var f in fieldsToSet)
+                {
+                    if (ReferenceEquals(f, rvField)) continue; // we'll set it below
+                    update.Set(f, f.AsObject(row));
+                }
+            }
+            else
+            {
+                foreach (var f in row.GetFields())
+                {
+                    if (ReferenceEquals(f, idField)) continue;
+                    if (ReferenceEquals(f, rvField)) continue; // we'll set it below
+                    if (excludeFields is not null && excludeFields.Contains(f)) continue;
+                    if (!row.IsAssigned(f)) continue;
+                    if ((f.Flags & FieldFlags.NotMapped) != 0) continue;
+                    if ((f.Flags & FieldFlags.Updatable) != FieldFlags.Updatable) continue;
+                    update.Set(f, f.AsObject(row));
+                }
+            }
+
+            update.Set(rvField, captured + 1);
+
+            update.Where(new BinaryCriteria(
+                new Criteria(idField),
+                CriteriaOperator.EQ,
+                new ValueCriteria(idValue)));
+            update.Where(new BinaryCriteria(
+                new Criteria(rvField),
+                CriteriaOperator.EQ,
+                new ValueCriteria(captured)));
+
+            // ExpectedRows.Ignore — we expect 0 (conflict) or 1 (success);
+            // either way it's not a "fail loudly on >1" scenario like the
+            // unguarded path.
+            var affected = update.Execute(c, ExpectedRows.Ignore);
+            if (affected == 0)
+                throw new OptimisticConcurrencyException(row.Table, idValue, captured);
+
+            // Row stayed put. Write the new RowVersion back so the caller can
+            // reuse the same instance for further updates without re-reading.
+            rvField.AsObject(row, (object?)(captured + 1));
+            return Task.FromResult(true);
         }, uow, ct);
     }
 
@@ -134,6 +237,13 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
                 "it in the SET list. Drop to SqlUpdate via ExecuteAsync to bypass.",
                 nameof(fields));
 
+        // [RowVersion]-guarded path: route through the shared write path.
+        // The guard is applied even when `fields` doesn't include RowVersion —
+        // optimistic concurrency is non-negotiable for versioned rows.
+        var rvField = RowVersionMetadata.Find(row);
+        if (rvField is not null)
+            return UpdateGuardedAsync(row, rvField, fields, excludeFields: null, uow, ct);
+
         return ExecuteAsync((c, _) =>
         {
             var update = SqlUpdate(row.Table);
@@ -181,6 +291,13 @@ public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : Reposi
                 "Row's Id must be set before calling UpdateExcludingAsync(row, excludeFields, ...).");
 
         var exclude = new HashSet<Field>(excludeFields);
+
+        // [RowVersion]-guarded path: route through the shared write path.
+        // The guard is applied even if RowVersion is in excludeFields —
+        // optimistic concurrency is non-negotiable, can't be excluded.
+        var rvField = RowVersionMetadata.Find(row);
+        if (rvField is not null)
+            return UpdateGuardedAsync(row, rvField, fieldsToSet: null, exclude, uow, ct);
 
         return ExecuteAsync((c, _) =>
         {

--- a/src/Idevs.Net.CoreLib/Repositories/RowVersionAttribute.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowVersionAttribute.cs
@@ -1,0 +1,39 @@
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Marks a <see cref="long"/>? property on a Serenity row as that row's
+/// optimistic-concurrency version counter. The
+/// <see cref="RepositoryBase{TRow,TKey}.UpdateAsync(TRow, Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
+/// overloads detect this attribute and guard the UPDATE with a
+/// <c>WHERE RowVersion = @captured</c> + <c>SET RowVersion = RowVersion + 1</c>
+/// pair; on conflict they throw <see cref="OptimisticConcurrencyException"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Apply to the property — not the field — so consumer rows pick up the
+/// flag through the standard Serenity attribute pipeline.
+/// </para>
+/// <para>
+/// Constraints (validated at first use, with an explicit error message
+/// when violated):
+/// </para>
+/// <list type="bullet">
+/// <item><description>At most one property per row may be flagged.</description></item>
+/// <item><description>The property type MUST be <see cref="long"/>? (nullable long).
+/// Other integer types are rejected for consistency.</description></item>
+/// <item><description>The corresponding <see cref="Serenity.Data.Field"/> in
+/// <c>RowFields</c> must exist and have <c>FieldFlags.Updatable</c> set, since
+/// the library overwrites the value as part of every guarded UPDATE.</description></item>
+/// </list>
+/// <para>
+/// <b>Schema:</b> the backing column is a plain <c>BIGINT NOT NULL DEFAULT 0</c>
+/// in every supported dialect — application-managed, portable across
+/// SqlServer / MySQL / MariaDB / PostgreSQL / Oracle / SQLite. The library
+/// does not use SqlServer's native <c>rowversion</c> / <c>timestamp</c> type;
+/// see MIGRATION.md (v0.7.7 → v0.7.8) for the rationale.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class RowVersionAttribute : Attribute
+{
+}

--- a/src/Idevs.Net.CoreLib/Repositories/RowVersionMetadata.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowVersionMetadata.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Serenity.Data;
+
+namespace Idevs.Repositories;
+
+/// <summary>
+/// Per-row-type lookup for the <see cref="RowVersionAttribute"/> field,
+/// cached forever after first resolution. Internal — consumers go
+/// through <see cref="RepositoryBase{TRow,TKey}"/> overloads.
+/// </summary>
+/// <remarks>
+/// Reflection runs at most once per <c>TRow</c>. After that every
+/// guarded UPDATE pays a single <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// lookup — no per-call attribute scan. Validation throws on misuse
+/// (multiple attributes, wrong property type, missing field, missing
+/// Updatable flag) at the first lookup, so configuration bugs surface
+/// immediately rather than silently disabling the guard.
+/// </remarks>
+internal static class RowVersionMetadata
+{
+    private static readonly ConcurrentDictionary<Type, Field?> _cache = new();
+
+    /// <summary>
+    /// Return the <see cref="Field"/> on <paramref name="row"/>'s type
+    /// flagged with <see cref="RowVersionAttribute"/>, or <c>null</c>
+    /// when the type is not opted in.
+    /// </summary>
+    public static Field? Find(IRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        return _cache.GetOrAdd(row.GetType(), t => Resolve(t, row));
+    }
+
+    private static Field? Resolve(Type rowType, IRow rowInstance)
+    {
+        var props = rowType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttribute<RowVersionAttribute>(inherit: true) is not null)
+            .ToArray();
+
+        if (props.Length == 0)
+            return null;
+
+        if (props.Length > 1)
+        {
+            var names = string.Join(", ", props.Select(p => p.Name));
+            throw new InvalidOperationException(
+                $"Row type '{rowType.FullName}' has {props.Length} [RowVersion] properties ({names}); " +
+                "expected at most one. Optimistic concurrency requires a single version column per row.");
+        }
+
+        var prop = props[0];
+
+        if (prop.PropertyType != typeof(long?))
+            throw new InvalidOperationException(
+                $"[RowVersion] property '{rowType.FullName}.{prop.Name}' must be of type 'long?'; " +
+                $"got '{prop.PropertyType}'. Use 'public long? {prop.Name} {{ get; set; }}' " +
+                "with a matching Int64Field in the row's RowFields class.");
+
+        var field = rowInstance.GetFields().FirstOrDefault(f =>
+            string.Equals(f.PropertyName, prop.Name, StringComparison.Ordinal));
+
+        if (field is null)
+            throw new InvalidOperationException(
+                $"[RowVersion] property '{rowType.FullName}.{prop.Name}' has no matching " +
+                $"Field in RowFields. Add 'public Int64Field {prop.Name};' to the RowFields class.");
+
+        if ((field.Flags & FieldFlags.Updatable) != FieldFlags.Updatable)
+            throw new InvalidOperationException(
+                $"[RowVersion] field '{rowType.FullName}.{prop.Name}' is not Updatable. " +
+                "The library increments this field on every guarded UPDATE; clearing the " +
+                "Updatable flag would prevent that. Remove the [SetFieldFlags] that clears it.");
+
+        return field;
+    }
+}

--- a/src/Idevs.Net.CoreLib/Repositories/RowVersionMetadata.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowVersionMetadata.cs
@@ -66,6 +66,13 @@ internal static class RowVersionMetadata
                 $"[RowVersion] property '{rowType.FullName}.{prop.Name}' has no matching " +
                 $"Field in RowFields. Add 'public Int64Field {prop.Name};' to the RowFields class.");
 
+        if ((field.Flags & FieldFlags.NotMapped) != 0)
+            throw new InvalidOperationException(
+                $"[RowVersion] field '{rowType.FullName}.{prop.Name}' has FieldFlags.NotMapped " +
+                "set. The library uses this column in both SET and WHERE on every guarded " +
+                "UPDATE, which would generate invalid SQL on a non-existent column. Remove " +
+                "the [NotMapped] attribute (or the [SetFieldFlags(NotMapped, …)] that sets it).");
+
         if ((field.Flags & FieldFlags.Updatable) != FieldFlags.Updatable)
             throw new InvalidOperationException(
                 $"[RowVersion] field '{rowType.FullName}.{prop.Name}' is not Updatable. " +

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/MsSqlContainerFixture.cs
@@ -89,7 +89,27 @@ public sealed class MsSqlContainerFixture : IAsyncLifetime
                 SequenceKey NVARCHAR(100) NOT NULL PRIMARY KEY,
                 NextValue BIGINT NOT NULL
             );
+
+            IF OBJECT_ID('dbo.VersionedTestRows', 'U') IS NOT NULL
+                DROP TABLE dbo.VersionedTestRows;
+
+            CREATE TABLE dbo.VersionedTestRows (
+                Id INT IDENTITY(1,1) PRIMARY KEY,
+                Code NVARCHAR(50) NOT NULL,
+                Amount DECIMAL(18,4) NOT NULL DEFAULT 0,
+                RowVersion BIGINT NOT NULL DEFAULT 0
+            );
             """);
+    }
+
+    /// <summary>
+    /// Truncate the VersionedTestRows table — call between tests in
+    /// optimistic-concurrency suites for isolation.
+    /// </summary>
+    public void TruncateVersionedTable()
+    {
+        using var conn = SqlConnections.NewByKey("Default");
+        SqlHelper.ExecuteNonQuery(conn, "TRUNCATE TABLE dbo.VersionedTestRows;");
     }
 
     /// <summary>

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/OptimisticConcurrencyTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/OptimisticConcurrencyTests.cs
@@ -1,0 +1,251 @@
+using Idevs.Repositories;
+using Serenity.Data;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Integration coverage for the <see cref="RowVersionAttribute"/>-driven
+/// optimistic-concurrency guard on <see cref="RepositoryBase{TRow,TKey}"/>'s
+/// three TRow-shaped UpdateAsync overloads. Verifies the happy path,
+/// the conflict-detection path, the manual retry loop, and confirms
+/// rows without [RowVersion] are unchanged from 0.7.7 behavior.
+/// </summary>
+[Collection(nameof(MsSqlContainerCollection))]
+[Trait("Category", "Integration")]
+public sealed class OptimisticConcurrencyTests : IDisposable
+{
+    private readonly MsSqlContainerFixture _fixture;
+    private readonly TestRepository _repo;
+    private static readonly VersionedTestRow.RowFields Fld = VersionedTestRow.Fields;
+
+    private sealed class TestRepository(ISqlConnections sqlConnections)
+        : RepositoryBase<VersionedTestRow, int>(sqlConnections);
+
+    public OptimisticConcurrencyTests(MsSqlContainerFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.TruncateVersionedTable();
+        _repo = new TestRepository(fixture.SqlConnections);
+    }
+
+    public void Dispose() => _fixture.TruncateVersionedTable();
+
+    private async Task<VersionedTestRow> SeedAsync(string code, decimal amount = 0m)
+    {
+        var newId = (int)await _repo.CreateAsync(new VersionedTestRow { Code = code, Amount = amount });
+        var row = await _repo.GetByIdAsync(newId);
+        Assert.NotNull(row);
+        return row!;
+    }
+
+    // ---------- happy path ----------
+
+    [Fact]
+    public async Task UpdateAsync_HappyPath_IncrementsRowVersion()
+    {
+        var row = await SeedAsync("A", 10m);
+        var initialVersion = row.RowVersion!.Value;
+
+        row.Amount = 99m;
+        var updated = await _repo.UpdateAsync(row);
+
+        Assert.True(updated);
+
+        // Library wrote the new version back to the in-memory instance.
+        Assert.Equal(initialVersion + 1, row.RowVersion);
+
+        // And the database actually advanced.
+        var fresh = await _repo.GetByIdAsync(row.Id!.Value);
+        Assert.NotNull(fresh);
+        Assert.Equal(99m, fresh!.Amount);
+        Assert.Equal(initialVersion + 1, fresh.RowVersion);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithFields_IncrementsRowVersion()
+    {
+        var row = await SeedAsync("B", 5m);
+        var initialVersion = row.RowVersion!.Value;
+
+        row.Amount = 50m;
+        var updated = await _repo.UpdateAsync(row, [Fld.Amount]);
+
+        Assert.True(updated);
+        Assert.Equal(initialVersion + 1, row.RowVersion);
+
+        var fresh = await _repo.GetByIdAsync(row.Id!.Value);
+        Assert.Equal(50m, fresh!.Amount);
+        Assert.Equal(initialVersion + 1, fresh.RowVersion);
+    }
+
+    [Fact]
+    public async Task UpdateExcludingAsync_IncrementsRowVersion_EvenIfRowVersionInExcludeList()
+    {
+        // Excluding RowVersion from the SET list does NOT bypass the guard.
+        // The library reapplies the increment regardless.
+        var row = await SeedAsync("C", 1m);
+        var initialVersion = row.RowVersion!.Value;
+
+        row.Amount = 7m;
+        var updated = await _repo.UpdateExcludingAsync(row, [Fld.RowVersion]);
+
+        Assert.True(updated);
+        Assert.Equal(initialVersion + 1, row.RowVersion);
+
+        var fresh = await _repo.GetByIdAsync(row.Id!.Value);
+        Assert.Equal(7m, fresh!.Amount);
+        Assert.Equal(initialVersion + 1, fresh.RowVersion);
+    }
+
+    // ---------- conflict detection ----------
+
+    [Fact]
+    public async Task UpdateAsync_StaleRowVersion_ThrowsOptimisticConcurrencyException()
+    {
+        var row = await SeedAsync("Race", 1m);
+        var stale = await _repo.GetByIdAsync(row.Id!.Value);   // Both copies have the same RowVersion.
+        Assert.NotNull(stale);
+
+        // First caller commits — RowVersion advances by 1.
+        row.Amount = 100m;
+        Assert.True(await _repo.UpdateAsync(row));
+
+        // Second caller, holding the now-stale version, must conflict.
+        stale!.Amount = 200m;
+        var ex = await Assert.ThrowsAsync<OptimisticConcurrencyException>(() =>
+            _repo.UpdateAsync(stale));
+
+        Assert.Contains("VersionedTestRows", ex.TableName);
+        Assert.Equal(row.Id, ex.RowId);
+        Assert.Equal(0L, ex.CapturedVersion);   // Both reads got version 0.
+
+        // Database state reflects the FIRST caller's win.
+        var fresh = await _repo.GetByIdAsync(row.Id!.Value);
+        Assert.Equal(100m, fresh!.Amount);
+        Assert.Equal(1L, fresh.RowVersion);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_FiftyConcurrentUpdaters_ExactlyOneSucceeds()
+    {
+        var row = await SeedAsync("Stampede", 1m);
+        var rowId = row.Id!.Value;
+
+        const int n = 50;
+
+        // Capture 50 stale copies BEFORE any UPDATE runs — without this
+        // step the read-then-write pairs interleave such that each task's
+        // SELECT picks up the previous task's increment and they all
+        // succeed sequentially. With all 50 holding version=0
+        // simultaneously, the update phase becomes a real race: exactly
+        // one wins, the other 49 must conflict.
+        var copies = new VersionedTestRow[n];
+        for (var i = 0; i < n; i++)
+        {
+            copies[i] = (await _repo.GetByIdAsync(rowId))!;
+            Assert.Equal(0L, copies[i].RowVersion);
+        }
+
+        var tasks = copies.Select(async (copy, i) =>
+        {
+            copy.Amount = i + 100m;
+            try
+            {
+                await _repo.UpdateAsync(copy);
+                return (success: true, conflict: false);
+            }
+            catch (OptimisticConcurrencyException)
+            {
+                return (success: false, conflict: true);
+            }
+        }).ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        var successes = results.Count(r => r.success);
+        var conflicts = results.Count(r => r.conflict);
+
+        Assert.Equal(1, successes);
+        Assert.Equal(n - 1, conflicts);
+
+        var fresh = await _repo.GetByIdAsync(rowId);
+        Assert.Equal(1L, fresh!.RowVersion); // exactly one increment
+    }
+
+    // ---------- manual retry pattern ----------
+
+    [Fact]
+    public async Task ManualRetryPattern_Succeeds()
+    {
+        var row = await SeedAsync("Retry", 0m);
+        var rowId = row.Id!.Value;
+
+        async Task IncrementWithRetryAsync(int rowId, int maxAttempts)
+        {
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                var fresh = await _repo.GetByIdAsync(rowId);
+                fresh!.Amount = (fresh.Amount ?? 0m) + 1m;
+                try
+                {
+                    await _repo.UpdateAsync(fresh);
+                    return;
+                }
+                catch (OptimisticConcurrencyException) when (attempt < maxAttempts)
+                {
+                    // re-read on next iteration
+                }
+            }
+            throw new InvalidOperationException("Max retries exceeded.");
+        }
+
+        // Five concurrent +1 increments; manual retry resolves all conflicts.
+        const int callers = 5;
+        await Task.WhenAll(Enumerable.Range(0, callers)
+            .Select(_ => IncrementWithRetryAsync(rowId, maxAttempts: callers + 2)));
+
+        var fresh = await _repo.GetByIdAsync(rowId);
+        Assert.Equal(callers, fresh!.Amount);
+        Assert.Equal(callers, fresh.RowVersion);
+    }
+
+    // ---------- precondition / misuse ----------
+
+    [Fact]
+    public async Task UpdateAsync_NullRowVersion_Throws()
+    {
+        // Construct a row by hand without reading it — RowVersion is null.
+        // The guard refuses to update silently when the captured version is unknown.
+        await SeedAsync("NoVersion", 0m);
+
+        var hand = new VersionedTestRow { Id = 1, Code = "NoVersion", Amount = 99m, RowVersion = null };
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _repo.UpdateAsync(hand));
+
+        Assert.Contains("RowVersion", ex.Message);
+        Assert.Contains("null", ex.Message);
+    }
+
+    // ---------- non-versioned regression ----------
+
+    [Fact]
+    public async Task NonVersionedRow_BehaviorUnchanged()
+    {
+        // IntegrationTestRow has no [RowVersion] — UpdateAsync should
+        // behave exactly as in 0.7.7: no exception type changes, no
+        // WHERE-RowVersion clause emitted. Quick sanity test against
+        // the existing IntegrationTestRow infrastructure.
+        var unversionedRepo = new RepositoryBase<IntegrationTestRow, int>(_fixture.SqlConnections);
+
+        var newId = (int)await unversionedRepo.CreateAsync(new IntegrationTestRow { Code = "Plain", Amount = 1m });
+        var row = await unversionedRepo.GetByIdAsync(newId);
+        row!.Amount = 999m;
+
+        // Should not throw, should not require a [RowVersion]-style guard.
+        Assert.True(await unversionedRepo.UpdateAsync(row));
+
+        // Cleanup so the existing IntegrationTestRow tests' baseline isn't polluted.
+        _fixture.TruncateTestTable();
+    }
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/VersionedTestRow.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/VersionedTestRow.cs
@@ -1,0 +1,38 @@
+using Serenity.ComponentModel;
+using Serenity.Data;
+using Serenity.Data.Mapping;
+
+namespace Idevs.Net.CoreLib.Tests.Integration;
+
+/// <summary>
+/// Row used by optimistic-concurrency integration tests. Carries a
+/// <see cref="RowVersionAttribute"/>-decorated <c>RowVersion</c> column;
+/// the library's <c>UpdateAsync(TRow, …)</c> overloads are expected to
+/// auto-detect it and apply the WHERE/SET guard.
+/// </summary>
+[ConnectionKey("Default"), Module("Integration"), TableName("[VersionedTestRows]")]
+public sealed class VersionedTestRow : Row<VersionedTestRow.RowFields>, IIdRow
+{
+    [Identity, IdProperty]
+    public int? Id { get => fields.Id[this]; set => fields.Id[this] = value; }
+
+    [Size(50), NotNull]
+    public string? Code { get => fields.Code[this]; set => fields.Code[this] = value; }
+
+    public decimal? Amount { get => fields.Amount[this]; set => fields.Amount[this] = value; }
+
+    [NotNull, Idevs.Repositories.RowVersion]
+    public long? RowVersion { get => fields.RowVersion[this]; set => fields.RowVersion[this] = value; }
+
+    public new static readonly RowFields Fields = (RowFields)new VersionedTestRow().GetFields();
+
+    public sealed class RowFields : RowFieldsBase
+    {
+#pragma warning disable CS8618 // populated by RowFieldsBase reflection
+        public Int32Field Id;
+        public StringField Code;
+        public DecimalField Amount;
+        public Int64Field RowVersion;
+#pragma warning restore CS8618
+    }
+}


### PR DESCRIPTION
## Summary

Opt-in optimistic concurrency for the row-shaped `UpdateAsync` overloads on `RepositoryBase<TRow, TKey>`. Rows without `[RowVersion]` see exactly today's behaviour. Rows with it get a portable, application-managed BIGINT counter that the library increments on every guarded UPDATE and a clear exception type on stale writes.

## Public surface

```csharp
namespace Idevs.Repositories;

[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
public sealed class RowVersionAttribute : Attribute { }

public sealed class OptimisticConcurrencyException : Exception
{
    public OptimisticConcurrencyException(string tableName, object? rowId, long capturedVersion);
    public string TableName { get; }
    public object? RowId { get; }
    public long CapturedVersion { get; }
}
```

That's it for new types. Behavioural change on three existing overloads (all on `RepositoryBase<TRow, TKey>`):

- `UpdateAsync(TRow row, …)`
- `UpdateAsync(TRow row, Field[] fields, …)`
- `UpdateExcludingAsync(TRow row, Field[] excludeFields, …)`

When the row carries a `[RowVersion]` field, each layers `WHERE RowVersion = @captured` + `SET RowVersion = RowVersion + 1` on top of its existing build, runs with `ExpectedRows.Ignore`, throws `OptimisticConcurrencyException` on 0 affected, and writes `captured + 1` back to the row instance on success. The criteria-based `UpdateAsync(Action<SqlUpdate>, …)` overload on `RepositoryBase<TRow>` is unchanged — caller owns the WHERE there.

## Caller shape

```csharp
public sealed class OrderRow : Row<OrderRow.RowFields>, IIdRow
{
    [Identity, IdProperty] public int? Id { … }
    [Size(50), NotNull]    public string? CustomerCode { … }

    [NotNull, RowVersion]                              // <-- one attribute
    public long? RowVersion { get => fields.RowVersion[this]; set => fields.RowVersion[this] = value; }

    public sealed class RowFields : RowFieldsBase
    {
        public Int32Field Id;
        public StringField CustomerCode;
        public Int64Field RowVersion;
    }
}

// Caller:
var order = await repo.GetByIdAsync(orderId);
order.CustomerCode = newCode;
try { await repo.UpdateAsync(order); }                 // 0 → 1
catch (OptimisticConcurrencyException) { /* re-read, retry */ }
```

## Design choices worth flagging

- **No `IUnitOfWork` parameter on the new types.** The guard runs inside whatever transaction the caller's `UpdateAsync` is in — same shape as today.
- **`long?` strict.** Other integer types are rejected at the first lookup with a clear error message.
- **Application-managed `BIGINT`, not native `rowversion`/`timestamp`.** Portable across SqlServer / MySQL/MariaDB / PostgreSQL / Oracle / SQLite. The native SqlServer type is `varbinary(8)`, isn't portable, and a 64-bit counter has plenty of range.
- **Validation fails loud at first lookup.** Multiple `[RowVersion]` properties, non-`long?` type, missing matching `Field`, `Updatable` flag cleared, `null` RowVersion at update time — all throw `InvalidOperationException` with a fix-it message. Result is cached so subsequent calls don't pay the reflection cost.
- **No built-in retry helper.** Number of retries / backoff / failure semantics are policy decisions. Document the manual try/retry shape; revisit if real demand emerges.

## Test plan

- [x] 8 integration tests in `OptimisticConcurrencyTests` (Testcontainers MSSQL 2022): happy path on all three overloads (`UpdateAsync(row)`, `UpdateAsync(row, fields)`, `UpdateExcludingAsync(row, excludeFields)`); single-conflict detection; **50-way stampede with all 50 readers capturing version 0 simultaneously — exactly 1 succeeds, 49 throw `OptimisticConcurrencyException`**; manual retry pattern (5 concurrent +1 increments resolved via re-read loop); `null` RowVersion precondition throws; non-versioned regression confirms `IntegrationTestRow` is unaffected.
- [x] Full library suite: **218 passed, 1 documented skip, 0 failures** on net8.0.
- [x] Release build produces `0.7.8.nupkg` for all four packable projects: `Idevs.Net.CoreLib`, `Idevs.Net.CoreLib.Autofac`, `Idevs.Net.CoreLib.Generators.Abstractions`, `Idevs.Net.CoreLib.Serilog`.
- [ ] Verify against MySQL / Postgres in production deployments before broad rollout.

## Schema

Add to existing tables that need optimistic concurrency:

```sql
ALTER TABLE Orders ADD RowVersion BIGINT NOT NULL DEFAULT 0;
```

The `DEFAULT 0` backfills existing rows. First update on any of those rows captures 0 and advances to 1. No data migration needed. Engine-specific DDL (with the right `ALTER TABLE` syntax for MySQL/Postgres) in `MIGRATION.md`.

## Docs

- `CHANGELOG.md` — full 0.7.8 entry covering Added / Changed / Validation / Verified / Notes.
- `MIGRATION.md` — new v0.7.7 → v0.7.8 section with worked example, schema DDL by engine, canonical retry pattern, full validation table, and five caveats (criteria-based path is NOT guarded, backfill semantics, reflection caching, no interference with `ISequenceProvider`, `CreateAsync` doesn't set RowVersion).
- `README.md` — new "Optimistic concurrency (0.7.8)" subsection under Repositories with the full row-class example and the caller pattern. Migration link list updated.

## Out of scope (future releases)

- Built-in `RetryOnConcurrencyConflictAsync` helper. Policy concern, document the manual shape for now. Revisit in 0.8.0+ if real demand.
- Native SqlServer `rowversion` / `timestamp` integration. Adds a parallel attribute (`[NativeRowVersion]`?) and complicates the type story. Only if asked.
- Auto-detection of column-type / schema mismatch at startup. Library doesn't ship migrations; not the place to start.