### PR TITLE
refactor: rename RepositoryBase → RowRepositoryBase + restore v0.3.3 legacy shim (0.7.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.7.9 (2026-05-12)
+
+### Changed
+
+- Renamed `Idevs.Repositories.RepositoryBase<TRow>` → `RowRepositoryBase<TRow>`
+  and `Idevs.Repositories.RepositoryBase<TRow, TKey>` → `RowRepositoryBase<TRow, TKey>`.
+  Behaviour is identical; only the type name changed. The `*REMOVED*` /
+  added entries are tracked in `PublicAPI.Unshipped.txt`.
+
+### Added
+
+- Re-introduced `Idevs.RepositoryBase<T>` (the v0.3.3 plumbing-only base
+  where `T` is the `ILogger<T>` category) as an `[Obsolete]` legacy class.
+  Body is identical to v0.3.3 — `ServiceProvider`, `ExceptionLog`,
+  `SqlConnections`, `Localizer`, `Connection`, `Dialect`, and the
+  `SqlQuery` / `SqlInsert(t)` / `SqlUpdate(t)` / `SqlDelete(t)` factories.
+  Downstream projects still on the v0.3.3 shape (notably PowerACC) compile
+  unchanged under `using Idevs;`. Scheduled for removal in v1.0.
+
+### Migration
+
+- New repositories: derive from `Idevs.Repositories.RowRepositoryBase<TRow>` /
+  `RowRepositoryBase<TRow, TKey>`.
+- Existing repositories on the v0.7.x API: rename the base class — the
+  primary-constructor shape `(ISqlConnections)` and every method signature
+  are unchanged.
+- Existing repositories on the v0.3.3 API: keep using `Idevs.RepositoryBase<T>`
+  during migration. Move to `RowRepositoryBase` before v1.0.
+
 ## 0.7.8 (2026-05-08)
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -76,12 +76,26 @@ moves:
 +    : RowRepositoryBase<OrderRow, int>(c), IOrderRepository { }
 ```
 
-A regex/sed pass is safe:
+A regex/sed pass is safe. The `-i` flag differs between BSD sed (macOS)
+and GNU sed (most Linux + CI), so pick the variant for your platform:
 
 ```bash
-# In your downstream repo
+# macOS (BSD sed) — empty string after -i
 grep -rln 'RepositoryBase<' --include='*.cs' \
     | xargs sed -i '' 's/RepositoryBase</RowRepositoryBase</g'
+
+# Linux / CI (GNU sed) — no argument after -i
+grep -rln 'RepositoryBase<' --include='*.cs' \
+    | xargs sed -i 's/RepositoryBase</RowRepositoryBase</g'
+```
+
+If you need one snippet that runs on both (e.g., in a script shared with
+CI), use the explicit-backup form and clean up afterwards:
+
+```bash
+grep -rln 'RepositoryBase<' --include='*.cs' \
+    | xargs sed -i.bak 's/RepositoryBase</RowRepositoryBase</g' \
+    && find . -name '*.bak' -delete
 ```
 
 Watch for two things during a mechanical replace:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,7 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 
 ## Contents
 
+- [v0.7.8 → v0.7.9 — RepositoryBase rename + v0.3.3 legacy shim](#v078--v079--repositorybase-rename--v033-legacy-shim)
 - [v0.7.7 → v0.7.8 — Optimistic concurrency on UpdateAsync](#v077--v078--optimistic-concurrency-on-updateasync)
 - [v0.7.6 → v0.7.7 — ISequenceProvider helper](#v076--v077--isequenceprovider-helper)
 - [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](#v075--v076--row-lock-primitives--innewtransactionasync)
@@ -16,6 +17,101 @@ Consolidated upgrade notes for `Idevs.Net.CoreLib`. Newest first.
 - [v0.3.x → v0.5.0 — Package Layout & DI Changes](#v03x--v050--package-layout--di-changes)
 - [v0.1.x → v0.2.0 — Autofac Integration](#v01x--v020--autofac-integration)
 - [v0.0.x → v0.1.x — Service Registration & Chrome Setup](#v00x--v01x--service-registration--chrome-setup)
+
+---
+
+## v0.7.8 → v0.7.9 — RepositoryBase rename + v0.3.3 legacy shim
+
+### What changed
+
+Two coordinated moves so downstream projects can migrate gradually:
+
+| Before (v0.7.8) | After (v0.7.9) |
+|---|---|
+| `Idevs.Repositories.RepositoryBase<TRow>` | `Idevs.Repositories.RowRepositoryBase<TRow>` |
+| `Idevs.Repositories.RepositoryBase<TRow, TKey>` | `Idevs.Repositories.RowRepositoryBase<TRow, TKey>` |
+| *(removed in 0.6.0)* | `Idevs.RepositoryBase<T>` re-introduced as `[Obsolete]`, v0.3.3 body verbatim |
+
+The rename is mechanical: primary-constructor shape `(ISqlConnections)`,
+every method signature, every behaviour is identical. Only the type name
+changed. PublicAPI tracking handled via `*REMOVED*` markers on the
+shipped entries plus the new shipped-shape entries on the renamed type.
+
+The re-introduced `Idevs.RepositoryBase<T>` is the v0.3.3 plumbing-only
+class — `T` is the `ILogger<T>` category type (NOT a Serenity row). Its
+ctor is `(IServiceProvider, ILogger<T>)`. It exposes `ServiceProvider`,
+`ExceptionLog`, `SqlConnections`, `Localizer`, `Connection`, `Dialect`,
+and the `SqlQuery` / `SqlInsert(t)` / `SqlUpdate(t)` / `SqlDelete(t)`
+factories. Marked `[Obsolete]`; scheduled for removal in **v1.0**.
+
+### Why the rename matters
+
+`RepositoryBase` carried two completely incompatible meanings across the
+v0.3.x and v0.6.x+ generations — same name, different generic parameter
+semantics (`T` as logger category vs. `TRow` as a Serenity `IRow`). Same
+name, two shapes, is a footgun for any downstream project that touches
+both eras. Renaming the typed-row variant to `RowRepositoryBase<TRow>`
+removes the ambiguity.
+
+### What you need to do
+
+**New repositories** — derive from `RowRepositoryBase` from day one:
+
+```csharp
+using Idevs.Repositories;
+
+public class OrderRepository(ISqlConnections c)
+    : RowRepositoryBase<OrderRow, int>(c), IOrderRepository
+{
+}
+```
+
+**Existing v0.7.x repositories** — rename the base class. Nothing else
+moves:
+
+```diff
+-public class OrderRepository(ISqlConnections c)
+-    : RepositoryBase<OrderRow, int>(c), IOrderRepository { }
++public class OrderRepository(ISqlConnections c)
++    : RowRepositoryBase<OrderRow, int>(c), IOrderRepository { }
+```
+
+A regex/sed pass is safe:
+
+```bash
+# In your downstream repo
+grep -rln 'RepositoryBase<' --include='*.cs' \
+    | xargs sed -i '' 's/RepositoryBase</RowRepositoryBase</g'
+```
+
+Watch for two things during a mechanical replace:
+
+1. **Your own classes named `RepositoryBase*`** (e.g., `AppRepositoryBase`,
+   `RepositoryBaseTests`). The pattern above is generic-aware so it only
+   touches generic uses, but verify with a `git diff` review.
+2. **Code on the v0.3.3 API** — see the next section.
+
+**Existing v0.3.3 repositories** (`Idevs.RepositoryBase<TSelf>` pattern,
+ctor `(IServiceProvider, ILogger<T>)`) — keep them on the legacy class
+for now; they continue to compile. The `[Obsolete]` warning is the only
+behavioural change. Plan migration to `RowRepositoryBase` before v1.0.
+
+### Why the legacy shim is full v0.3.3 body, not a subclass
+
+The two `RepositoryBase` classes have incompatible ctors and protected
+surfaces (logger category vs. Serenity row; service-provider injection
+vs. `ISqlConnections`). A subclass shim cannot bridge them. The legacy
+class is restored verbatim so downstream code that calls
+`base(serviceProvider, logger)`, reads `Connection`, or composes
+`SqlQuery() / SqlInsert(table)` keeps working unmodified.
+
+### Removal timeline
+
+- **0.7.9** (this release) — rename ships. `RepositoryBase` (typed-row) is
+  gone from `Idevs.Repositories`. Legacy `Idevs.RepositoryBase<T>` ships
+  as `[Obsolete]`.
+- **0.8.x → 0.9.x** — `[Obsolete]` warnings continue. No behaviour change.
+- **1.0** — `Idevs.RepositoryBase<T>` removed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ using Idevs.Repositories;
 using Serenity.Data; // ISqlConnections, IRow, IIdRow
 
 public abstract class AppRepositoryBase<TRow, TKey>(ISqlConnections c)
-    : RepositoryBase<TRow, TKey>(c), IScopedService
+    : RowRepositoryBase<TRow, TKey>(c), IScopedService
     where TRow : class, IRow, IIdRow, new()
 {
 }
@@ -192,7 +192,7 @@ Three layered base classes for data access:
 
 - **`SqlServiceBase`** — for services that need raw SQL access without being a typed repository. Provides `ISqlConnections`, lazy `Dialect`, dialect-pre-bound `SqlQuery()` / `SqlInsert(t)` / `SqlUpdate(t)` factories, a `SqlDelete(t)` factory (Serenity's `SqlDelete` exposes no chainable `Dialect()` setter, so the active connection's dialect is used at `Execute` time), and a uniform `ExecuteAsync<T>` template that manages connection lifetime and composes with an optional `UnitOfWork`.
 
-- **`RepositoryBase<TRow>`** — typed read/list/getby/create/update/delete on a Serenity `IRow`:
+- **`RowRepositoryBase<TRow>`** — typed read/list/getby/create/update/delete on a Serenity `IRow`. (Renamed in 0.7.9 from `RepositoryBase<TRow>`; the v0.3.3-shaped `Idevs.RepositoryBase<T>` is still shipped as `[Obsolete]` for downstream migration.)
 
   | Group | Methods |
   |---|---|
@@ -202,13 +202,13 @@ Three layered base classes for data access:
 
   `UpdateAsync` and `DeleteAsync` default to `ExpectedRows.One` so a wrong WHERE clause fails loudly — use the `*Many` variants or pass `ExpectedRows.Ignore` for batch operations. `CreateAsync` is an insert and has no row-count assertion: it returns the new identity for rows that implement `IIdRow`, or `0` otherwise.
 
-- **`RepositoryBase<TRow, TKey>`** — adds Id-keyed CRUD on `IIdRow`: `GetByIdAsync(TKey)`, `GetByIdsAsync(IEnumerable<TKey>)`, `UpdateAsync(TRow row)` (entity-by-id), `DeleteByIdAsync(TKey)`. Inherits all criteria-based methods from `RepositoryBase<TRow>`. The `UpdateAsync(TRow)` and `UpdateAsync(Action<SqlUpdate>, ...)` overloads coexist by signature.
+- **`RowRepositoryBase<TRow, TKey>`** — adds Id-keyed CRUD on `IIdRow`: `GetByIdAsync(TKey)`, `GetByIdsAsync(IEnumerable<TKey>)`, `UpdateAsync(TRow row)` (entity-by-id), `DeleteByIdAsync(TKey)`. Inherits all criteria-based methods from `RowRepositoryBase<TRow>`. The `UpdateAsync(TRow)` and `UpdateAsync(Action<SqlUpdate>, ...)` overloads coexist by signature.
 
 Connection key is configurable via the virtual `ConnectionKey` property or the `[ConnectionKey("Warehouse")]` attribute (resolved on the derived class).
 
 #### Optimistic concurrency (0.7.8)
 
-Mark a `long?` property with `[RowVersion]` and the three TRow-shaped `UpdateAsync` overloads on `RepositoryBase<TRow, TKey>` automatically guard the UPDATE with `WHERE RowVersion = @captured` and `SET RowVersion = RowVersion + 1`. On a stale write the library throws `OptimisticConcurrencyException` carrying `TableName`, `RowId`, and `CapturedVersion`:
+Mark a `long?` property with `[RowVersion]` and the three TRow-shaped `UpdateAsync` overloads on `RowRepositoryBase<TRow, TKey>` automatically guard the UPDATE with `WHERE RowVersion = @captured` and `SET RowVersion = RowVersion + 1`. On a stale write the library throws `OptimisticConcurrencyException` carrying `TableName`, `RowId`, and `CapturedVersion`:
 
 ```csharp
 public sealed class OrderRow : Row<OrderRow.RowFields>, IIdRow
@@ -314,7 +314,7 @@ public interface IMappingLotRepository
 
 [Scoped(typeof(IMappingLotRepository))]
 public class MappingLotRepository(ISqlConnections c)
-    : RepositoryBase<MappingLotSelectionRow>(c), IMappingLotRepository
+    : RowRepositoryBase<MappingLotSelectionRow>(c), IMappingLotRepository
 {
     private static readonly MappingLotSelectionRow.RowFields cFld = MappingLotSelectionRow.Fields;
 
@@ -709,6 +709,7 @@ If the generator misbehaves on a specific build, set `<IdevsCoreLibUseSourceGene
 
 Detailed upgrade notes for every minor and major version live in [MIGRATION.md](MIGRATION.md). Latest transitions:
 
+- [v0.7.8 → v0.7.9 — RepositoryBase rename + v0.3.3 legacy shim](MIGRATION.md#v078--v079--repositorybase-rename--v033-legacy-shim)
 - [v0.7.7 → v0.7.8 — Optimistic concurrency on UpdateAsync](MIGRATION.md#v077--v078--optimistic-concurrency-on-updateasync)
 - [v0.7.6 → v0.7.7 — ISequenceProvider helper](MIGRATION.md#v076--v077--isequenceprovider-helper)
 - [v0.7.5 → v0.7.6 — Row-lock primitives + InNewTransactionAsync](MIGRATION.md#v075--v076--row-lock-primitives--innewtransactionasync)

--- a/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
+++ b/src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>Idevs.Net.CoreLib</PackageId>
-    <Version>0.7.8</Version>
+    <Version>0.7.9</Version>
     <PackageTags>Idevs; CoreLib; Serenity; Extended</PackageTags>
     <Description>A library to extend Serenity Framework.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -9,28 +9,28 @@ Idevs.Repositories.SqlServiceBase.CommitOnSuccessAsync<T>(System.Func<Serenity.D
 Idevs.Repositories.SqlServiceBase.CommitOnSuccessAsync(System.Func<Serenity.Data.IUnitOfWork, System.Threading.CancellationToken, System.Threading.Tasks.Task> work, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Idevs.Repositories.SqlServiceBase.CommitOnSuccess<T>(System.Func<Serenity.Data.IUnitOfWork, T> work, Serenity.Data.IUnitOfWork uow = null) -> T
 Idevs.Repositories.SqlServiceBase.CommitOnSuccess(System.Action<Serenity.Data.IUnitOfWork> work, Serenity.Data.IUnitOfWork uow = null) -> void
-virtual Idevs.Repositories.RepositoryBase<TRow>.TryFirstAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
-virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateManyAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteManyAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
-virtual Idevs.Repositories.RepositoryBase<TRow>.TryFirst(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> TRow
-virtual Idevs.Repositories.RepositoryBase<TRow>.Update(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.UpdateMany(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.Delete(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.DeleteMany(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null) -> int
-virtual Idevs.Repositories.RepositoryBase<TRow>.CreateAsync(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
-virtual Idevs.Repositories.RepositoryBase<TRow>.Create(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null) -> long
-virtual Idevs.Repositories.RepositoryBase<TRow>.CreateExcludingAsync(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
-virtual Idevs.Repositories.RepositoryBase<TRow>.CreateExcluding(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null) -> long
-virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateAsync(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
-virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.Update(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null) -> bool
-virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateExcludingAsync(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
-virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateExcluding(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null) -> bool
-virtual Idevs.Repositories.RepositoryBase<TRow>.CountAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
-virtual Idevs.Repositories.RepositoryBase<TRow>.ExistsAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
-virtual Idevs.Repositories.RepositoryBase<TRow>.Count(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> long
-virtual Idevs.Repositories.RepositoryBase<TRow>.Exists(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> bool
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.TryFirstAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.UpdateAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.UpdateManyAsync(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.DeleteAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.DeleteManyAsync(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.TryFirst(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> TRow
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.Update(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.UpdateMany(System.Action<Serenity.Data.SqlUpdate> configure, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.Delete(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.ExpectedRows expectedRows = Serenity.Data.ExpectedRows.One, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.DeleteMany(System.Action<Serenity.Data.SqlDelete> configure, Serenity.Data.IUnitOfWork uow = null) -> int
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.CreateAsync(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.Create(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null) -> long
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.CreateExcludingAsync(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.CreateExcluding(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null) -> long
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.UpdateAsync(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.Update(TRow row, Serenity.Data.Field[] fields, Serenity.Data.IUnitOfWork uow = null) -> bool
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.UpdateExcludingAsync(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.UpdateExcluding(TRow row, Serenity.Data.Field[] excludeFields, Serenity.Data.IUnitOfWork uow = null) -> bool
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.CountAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.ExistsAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.Count(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> long
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.Exists(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> bool
 Idevs.Repositories.SqlServiceBase.ExecuteScalarAsync<T>(string sql, System.Collections.Generic.IDictionary<string, object> parameters = null, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>
 Idevs.Repositories.SqlServiceBase.ExecuteNonQueryAsync(string sql, System.Collections.Generic.IDictionary<string, object> parameters = null, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<int>
 Idevs.Repositories.SqlServiceBase.ExecuteScalar<T>(string sql, System.Collections.Generic.IDictionary<string, object> parameters = null, Serenity.Data.IUnitOfWork uow = null) -> T
@@ -42,3 +42,55 @@ Idevs.Repositories.OptimisticConcurrencyException.OptimisticConcurrencyException
 Idevs.Repositories.OptimisticConcurrencyException.TableName.get -> string
 Idevs.Repositories.OptimisticConcurrencyException.RowId.get -> object
 Idevs.Repositories.OptimisticConcurrencyException.CapturedVersion.get -> long
+*REMOVED*Idevs.Repositories.RepositoryBase<TRow, TKey>
+*REMOVED*Idevs.Repositories.RepositoryBase<TRow, TKey>.RepositoryBase(Serenity.Data.ISqlConnections sqlConnections) -> void
+*REMOVED*Idevs.Repositories.RepositoryBase<TRow>
+*REMOVED*Idevs.Repositories.RepositoryBase<TRow>.RepositoryBase(Serenity.Data.ISqlConnections sqlConnections) -> void
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.DeleteById(TKey id, Serenity.Data.IUnitOfWork uow = null) -> bool
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.DeleteByIdAsync(TKey id, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.GetById(TKey id, Serenity.Data.IUnitOfWork uow = null) -> TRow
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.GetByIdAsync(TKey id, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.GetByIds(System.Collections.Generic.IEnumerable<TKey> ids, Serenity.Data.IUnitOfWork uow = null) -> System.Collections.Generic.List<TRow>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.GetByIdsAsync(System.Collections.Generic.IEnumerable<TKey> ids, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.List<TRow>>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.Update(TRow row, Serenity.Data.IUnitOfWork uow = null) -> bool
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow, TKey>.UpdateAsync(TRow row, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.Create(TRow row, Serenity.Data.IUnitOfWork uow = null) -> long
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.CreateAsync(TRow row, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.First(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> TRow
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.FirstAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.GetBy<TValue>(Serenity.Data.Field keyField, TValue value, Serenity.Data.IUnitOfWork uow = null) -> TRow
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.GetByAsync<TValue>(Serenity.Data.Field keyField, TValue value, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.List(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> System.Collections.Generic.List<TRow>
+*REMOVED*virtual Idevs.Repositories.RepositoryBase<TRow>.ListAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.List<TRow>>
+Idevs.Repositories.RowRepositoryBase<TRow, TKey>
+Idevs.Repositories.RowRepositoryBase<TRow, TKey>.RowRepositoryBase(Serenity.Data.ISqlConnections sqlConnections) -> void
+Idevs.Repositories.RowRepositoryBase<TRow>
+Idevs.Repositories.RowRepositoryBase<TRow>.RowRepositoryBase(Serenity.Data.ISqlConnections sqlConnections) -> void
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.DeleteById(TKey id, Serenity.Data.IUnitOfWork uow = null) -> bool
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.DeleteByIdAsync(TKey id, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.GetById(TKey id, Serenity.Data.IUnitOfWork uow = null) -> TRow
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.GetByIdAsync(TKey id, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.GetByIds(System.Collections.Generic.IEnumerable<TKey> ids, Serenity.Data.IUnitOfWork uow = null) -> System.Collections.Generic.List<TRow>
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.GetByIdsAsync(System.Collections.Generic.IEnumerable<TKey> ids, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.List<TRow>>
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.Update(TRow row, Serenity.Data.IUnitOfWork uow = null) -> bool
+virtual Idevs.Repositories.RowRepositoryBase<TRow, TKey>.UpdateAsync(TRow row, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.Create(TRow row, Serenity.Data.IUnitOfWork uow = null) -> long
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.CreateAsync(TRow row, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.First(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> TRow
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.FirstAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.GetBy<TValue>(Serenity.Data.Field keyField, TValue value, Serenity.Data.IUnitOfWork uow = null) -> TRow
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.GetByAsync<TValue>(Serenity.Data.Field keyField, TValue value, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TRow>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.List(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null) -> System.Collections.Generic.List<TRow>
+virtual Idevs.Repositories.RowRepositoryBase<TRow>.ListAsync(System.Action<Serenity.Data.SqlQuery> configure, Serenity.Data.IUnitOfWork uow = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.List<TRow>>
+Idevs.RepositoryBase<T>
+Idevs.RepositoryBase<T>.RepositoryBase(System.IServiceProvider serviceProvider, Microsoft.Extensions.Logging.ILogger<T> logger) -> void
+Idevs.RepositoryBase<T>.Connection.get -> System.Data.IDbConnection
+Idevs.RepositoryBase<T>.Dialect.get -> Serenity.Data.ISqlDialect
+Idevs.RepositoryBase<T>.ExceptionLog.get -> Microsoft.Extensions.Logging.ILogger<T>
+Idevs.RepositoryBase<T>.Localizer.get -> Serenity.ITextLocalizer
+Idevs.RepositoryBase<T>.ServiceProvider.get -> System.IServiceProvider
+Idevs.RepositoryBase<T>.SqlConnections.get -> Serenity.Data.ISqlConnections
+Idevs.RepositoryBase<T>.SqlDelete(string tableName) -> Serenity.Data.SqlDelete
+Idevs.RepositoryBase<T>.SqlInsert(string tableName) -> Serenity.Data.SqlInsert
+Idevs.RepositoryBase<T>.SqlQuery.get -> Serenity.Data.SqlQuery
+Idevs.RepositoryBase<T>.SqlUpdate(string tableName) -> Serenity.Data.SqlUpdate

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -96,3 +96,34 @@ Idevs.RepositoryBase<T>.SqlQuery.get -> Serenity.Data.SqlQuery
 Idevs.RepositoryBase<T>.SqlUpdate(string tableName) -> Serenity.Data.SqlUpdate
 Idevs.RepositoryBase<T>.Dispose() -> void
 virtual Idevs.RepositoryBase<T>.Dispose(bool disposing) -> void
+Idevs.Repositories.LockMode
+Idevs.Repositories.LockMode.Share = 1 -> Idevs.Repositories.LockMode
+Idevs.Repositories.LockMode.Update = 0 -> Idevs.Repositories.LockMode
+Idevs.Repositories.LockMode.UpdateNoWait = 2 -> Idevs.Repositories.LockMode
+Idevs.Repositories.LockMode.UpdateSkip = 3 -> Idevs.Repositories.LockMode
+Idevs.Repositories.SqlQueryLockExtensions
+static Idevs.Repositories.SqlQueryLockExtensions.ForUpdate(this Serenity.Data.SqlQuery! query, Idevs.Repositories.LockMode mode = Idevs.Repositories.LockMode.Update) -> Serenity.Data.SqlQuery!
+Idevs.Repositories.SqlServiceBase.InNewTransactionAsync<T>(System.Func<Serenity.Data.IUnitOfWork!, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>!>! work, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<T>!
+Idevs.Repositories.SqlServiceBase.InNewTransactionAsync(System.Func<Serenity.Data.IUnitOfWork!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! work, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Idevs.Repositories.Sequences.ISequenceProvider
+Idevs.Repositories.Sequences.ISequenceProvider.EnsureSequenceAsync(string! sequenceKey, long startValue = 1, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Idevs.Repositories.Sequences.ISequenceProvider.NextAsync(string! sequenceKey, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>!
+Idevs.Repositories.Sequences.ISequenceProvider.NextRangeAsync(string! sequenceKey, int count, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<long>!>!
+Idevs.Repositories.Sequences.SequenceServiceCollectionExtensions
+static Idevs.Repositories.Sequences.SequenceServiceCollectionExtensions.AddIdevsSequenceProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Idevs.Repositories.Sequences.SqlSequenceProvider
+Idevs.Repositories.Sequences.SqlSequenceProvider.SqlSequenceProvider(Serenity.Data.ISqlConnections! sqlConnections) -> void
+Idevs.Repositories.Sequences.SqlSequenceProvider.EnsureSequenceAsync(string! sequenceKey, long startValue = 1, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Idevs.Repositories.Sequences.SqlSequenceProvider.NextAsync(string! sequenceKey, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<long>!
+Idevs.Repositories.Sequences.SqlSequenceProvider.NextRangeAsync(string! sequenceKey, int count, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<long>!>!
+Idevs.Repositories.Sequences.IdevsSequenceRow
+Idevs.Repositories.Sequences.IdevsSequenceRow.IdevsSequenceRow() -> void
+Idevs.Repositories.Sequences.IdevsSequenceRow.NextValue.get -> long?
+Idevs.Repositories.Sequences.IdevsSequenceRow.NextValue.set -> void
+Idevs.Repositories.Sequences.IdevsSequenceRow.SequenceKey.get -> string?
+Idevs.Repositories.Sequences.IdevsSequenceRow.SequenceKey.set -> void
+static readonly Idevs.Repositories.Sequences.IdevsSequenceRow.Fields -> Idevs.Repositories.Sequences.IdevsSequenceRow.RowFields!
+Idevs.Repositories.Sequences.IdevsSequenceRow.RowFields
+Idevs.Repositories.Sequences.IdevsSequenceRow.RowFields.RowFields() -> void
+Idevs.Repositories.Sequences.IdevsSequenceRow.RowFields.NextValue -> Serenity.Data.Int64Field!
+Idevs.Repositories.Sequences.IdevsSequenceRow.RowFields.SequenceKey -> Serenity.Data.StringField!

--- a/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
+++ b/src/Idevs.Net.CoreLib/PublicAPI.Unshipped.txt
@@ -94,3 +94,5 @@ Idevs.RepositoryBase<T>.SqlDelete(string tableName) -> Serenity.Data.SqlDelete
 Idevs.RepositoryBase<T>.SqlInsert(string tableName) -> Serenity.Data.SqlInsert
 Idevs.RepositoryBase<T>.SqlQuery.get -> Serenity.Data.SqlQuery
 Idevs.RepositoryBase<T>.SqlUpdate(string tableName) -> Serenity.Data.SqlUpdate
+Idevs.RepositoryBase<T>.Dispose() -> void
+virtual Idevs.RepositoryBase<T>.Dispose(bool disposing) -> void

--- a/src/Idevs.Net.CoreLib/Repositories/RowLockSqlBuilder.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowLockSqlBuilder.cs
@@ -7,7 +7,7 @@ namespace Idevs.Repositories;
 /// Applies dialect-specific row-lock hints to a materialised SELECT statement.
 /// Internal — callers go through
 /// <see cref="SqlQueryLockExtensions.ForUpdate"/> on a query that is then
-/// materialised by <see cref="RepositoryBase{TRow}.TryFirstAsync"/> or a
+/// materialised by <see cref="RowRepositoryBase{TRow}.TryFirstAsync"/> or a
 /// sibling helper.
 /// </summary>
 internal static class RowLockSqlBuilder

--- a/src/Idevs.Net.CoreLib/Repositories/RowRepositoryBase.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowRepositoryBase.cs
@@ -8,7 +8,7 @@ namespace Idevs.Repositories;
 /// template inherited from <see cref="SqlServiceBase"/>.
 /// </summary>
 /// <typeparam name="TRow">A Serenity row type.</typeparam>
-public class RepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBase(sqlConnections)
+public class RowRepositoryBase<TRow>(ISqlConnections sqlConnections) : SqlServiceBase(sqlConnections)
     where TRow : class, IRow, new()
 {
     /// <summary>Return the first row that matches the configured query, or null.</summary>

--- a/src/Idevs.Net.CoreLib/Repositories/RowRepositoryBaseTKey.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowRepositoryBaseTKey.cs
@@ -4,11 +4,11 @@ namespace Idevs.Repositories;
 
 /// <summary>
 /// Typed repository base for a Serenity <see cref="IIdRow"/>. Adds Id-keyed
-/// CRUD shortcuts on top of <see cref="RepositoryBase{TRow}"/>.
+/// CRUD shortcuts on top of <see cref="RowRepositoryBase{TRow}"/>.
 /// </summary>
 /// <typeparam name="TRow">A Serenity row that implements <see cref="IIdRow"/>.</typeparam>
 /// <typeparam name="TKey">The Id value type (typically <see cref="int"/> or <see cref="long"/>).</typeparam>
-public class RepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : RepositoryBase<TRow>(sqlConnections)
+public class RowRepositoryBase<TRow, TKey>(ISqlConnections sqlConnections) : RowRepositoryBase<TRow>(sqlConnections)
     where TRow : class, IRow, IIdRow, new()
 {
     /// <summary>Fetch a single row by its Id, or null if not found.</summary>

--- a/src/Idevs.Net.CoreLib/Repositories/RowVersionAttribute.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowVersionAttribute.cs
@@ -3,7 +3,7 @@ namespace Idevs.Repositories;
 /// <summary>
 /// Marks a <see cref="long"/>? property on a Serenity row as that row's
 /// optimistic-concurrency version counter. The
-/// <see cref="RepositoryBase{TRow,TKey}.UpdateAsync(TRow, Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
+/// <see cref="RowRepositoryBase{TRow,TKey}.UpdateAsync(TRow, Serenity.Data.IUnitOfWork?, System.Threading.CancellationToken)"/>
 /// overloads detect this attribute and guard the UPDATE with a
 /// <c>WHERE RowVersion = @captured</c> + <c>SET RowVersion = RowVersion + 1</c>
 /// pair; on conflict they throw <see cref="OptimisticConcurrencyException"/>.

--- a/src/Idevs.Net.CoreLib/Repositories/RowVersionMetadata.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/RowVersionMetadata.cs
@@ -7,7 +7,7 @@ namespace Idevs.Repositories;
 /// <summary>
 /// Per-row-type lookup for the <see cref="RowVersionAttribute"/> field,
 /// cached forever after first resolution. Internal — consumers go
-/// through <see cref="RepositoryBase{TRow,TKey}"/> overloads.
+/// through <see cref="RowRepositoryBase{TRow,TKey}"/> overloads.
 /// </summary>
 /// <remarks>
 /// Reflection runs at most once per <c>TRow</c>. After that every

--- a/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/Sequences/SqlSequenceProvider.cs
@@ -29,7 +29,7 @@ namespace Idevs.Repositories.Sequences;
 /// </remarks>
 [Scoped(ServiceType = typeof(ISequenceProvider))]
 public sealed class SqlSequenceProvider(ISqlConnections sqlConnections)
-    : RepositoryBase<IdevsSequenceRow>(sqlConnections), ISequenceProvider
+    : RowRepositoryBase<IdevsSequenceRow>(sqlConnections), ISequenceProvider
 {
     private static readonly IdevsSequenceRow.RowFields Fld = IdevsSequenceRow.Fields;
 

--- a/src/Idevs.Net.CoreLib/Repositories/SqlQueryLockExtensions.cs
+++ b/src/Idevs.Net.CoreLib/Repositories/SqlQueryLockExtensions.cs
@@ -6,11 +6,11 @@ namespace Idevs.Repositories;
 /// <summary>
 /// Fluent <see cref="SqlQuery"/> extension that flags a SELECT for row-level
 /// locking. The lock hint is materialised at execution time by
-/// <see cref="RepositoryBase{TRow}.TryFirstAsync"/>.
+/// <see cref="RowRepositoryBase{TRow}.TryFirstAsync"/>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Currently honoured by:</b> <see cref="RepositoryBase{TRow}.TryFirstAsync"/> only.
+/// <b>Currently honoured by:</b> <see cref="RowRepositoryBase{TRow}.TryFirstAsync"/> only.
 /// <c>ListAsync</c>, <c>CountAsync</c>, <c>ExistsAsync</c>, and <c>GetByIdAsync</c>
 /// run through Serenity's standard execution path and silently ignore the
 /// flag. Coverage will expand in a follow-up release; in the meantime, the

--- a/src/Idevs.Net.CoreLib/RepositoryBase.cs
+++ b/src/Idevs.Net.CoreLib/RepositoryBase.cs
@@ -11,17 +11,31 @@ namespace Idevs;
 /// is the <see cref="ILogger{T}"/> category type — NOT a Serenity row.
 /// </summary>
 /// <remarks>
-/// Restored verbatim from v0.3.3 to keep downstream projects (notably PowerACC)
+/// <para>
+/// Restored from v0.3.3 to keep downstream projects (notably PowerACC)
 /// compiling while they migrate to the async-first
 /// <see cref="Repositories.RowRepositoryBase{TRow}"/> /
 /// <see cref="Repositories.RowRepositoryBase{TRow, TKey}"/> surface in
 /// <c>Idevs.Repositories</c>. New code should not derive from this type.
+/// </para>
+/// <para>
+/// Differences from the v0.3.3 verbatim body: implements
+/// <see cref="IDisposable"/> so the inner <see cref="IServiceScope"/> created
+/// in the constructor is released (v0.3.3 leaked it for the lifetime of the
+/// repository), and <see cref="Dialect"/> is lazily cached so reading it does
+/// not allocate a throwaway <see cref="IDbConnection"/> on every access.
+/// Behaviour from the caller's perspective is unchanged.
+/// </para>
 /// </remarks>
 /// <typeparam name="T">Type used for logging context.</typeparam>
 [Obsolete("Use Idevs.Repositories.RowRepositoryBase<TRow> or RowRepositoryBase<TRow, TKey>. " +
     "This v0.3.3 shape is kept for downstream migration and will be removed in v1.0.")]
-public class RepositoryBase<T>
+public class RepositoryBase<T> : IDisposable
 {
+    private readonly IServiceScope _scope;
+    private ISqlDialect? _cachedDialect;
+    private bool _disposed;
+
     protected IServiceProvider ServiceProvider { get; }
     protected ILogger<T> ExceptionLog { get; }
     protected ISqlConnections SqlConnections { get; }
@@ -35,12 +49,44 @@ public class RepositoryBase<T>
     public RepositoryBase(IServiceProvider serviceProvider, ILogger<T> logger)
     {
         ServiceProvider = serviceProvider;
-        var scoped = serviceProvider.CreateScope();
-        SqlConnections = scoped.ServiceProvider.GetRequiredService<ISqlConnections>();
+        _scope = serviceProvider.CreateScope();
+        SqlConnections = _scope.ServiceProvider.GetRequiredService<ISqlConnections>();
         ExceptionLog = logger;
-        Localizer = scoped.ServiceProvider.GetRequiredService<ITextLocalizer>();
+        Localizer = _scope.ServiceProvider.GetRequiredService<ITextLocalizer>();
     }
 
+    /// <summary>
+    /// Returns a NEW <see cref="IDbConnection"/> on every read. The caller owns
+    /// disposal — typically <c>using var conn = Connection;</c>. Reading this
+    /// property without disposing the returned instance leaks the connection.
+    /// </summary>
     protected IDbConnection Connection => SqlConnections.NewByKey("Default");
-    protected ISqlDialect Dialect => Connection.GetDialect();
+
+    /// <summary>
+    /// Active SQL dialect for the <c>"Default"</c> connection key, resolved
+    /// once and cached. The throwaway <see cref="IDbConnection"/> used for
+    /// the first resolution is disposed inline.
+    /// </summary>
+    protected ISqlDialect Dialect
+    {
+        get
+        {
+            if (_cachedDialect is not null) return _cachedDialect;
+            using var c = SqlConnections.NewByKey("Default");
+            return _cachedDialect = c.GetDialect();
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing) _scope.Dispose();
+        _disposed = true;
+    }
 }

--- a/src/Idevs.Net.CoreLib/RepositoryBase.cs
+++ b/src/Idevs.Net.CoreLib/RepositoryBase.cs
@@ -1,0 +1,46 @@
+using System.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serenity;
+using Serenity.Data;
+
+namespace Idevs;
+
+/// <summary>
+/// Legacy v0.3.3 repository base. The <typeparamref name="T"/> generic parameter
+/// is the <see cref="ILogger{T}"/> category type — NOT a Serenity row.
+/// </summary>
+/// <remarks>
+/// Restored verbatim from v0.3.3 to keep downstream projects (notably PowerACC)
+/// compiling while they migrate to the async-first
+/// <see cref="Repositories.RowRepositoryBase{TRow}"/> /
+/// <see cref="Repositories.RowRepositoryBase{TRow, TKey}"/> surface in
+/// <c>Idevs.Repositories</c>. New code should not derive from this type.
+/// </remarks>
+/// <typeparam name="T">Type used for logging context.</typeparam>
+[Obsolete("Use Idevs.Repositories.RowRepositoryBase<TRow> or RowRepositoryBase<TRow, TKey>. " +
+    "This v0.3.3 shape is kept for downstream migration and will be removed in v1.0.")]
+public class RepositoryBase<T>
+{
+    protected IServiceProvider ServiceProvider { get; }
+    protected ILogger<T> ExceptionLog { get; }
+    protected ISqlConnections SqlConnections { get; }
+    protected ITextLocalizer Localizer { get; }
+
+    protected SqlQuery SqlQuery => new SqlQuery();
+    protected SqlInsert SqlInsert(string tableName) => new SqlInsert(tableName);
+    protected SqlUpdate SqlUpdate(string tableName) => new SqlUpdate(tableName);
+    protected SqlDelete SqlDelete(string tableName) => new SqlDelete(tableName);
+
+    public RepositoryBase(IServiceProvider serviceProvider, ILogger<T> logger)
+    {
+        ServiceProvider = serviceProvider;
+        var scoped = serviceProvider.CreateScope();
+        SqlConnections = scoped.ServiceProvider.GetRequiredService<ISqlConnections>();
+        ExceptionLog = logger;
+        Localizer = scoped.ServiceProvider.GetRequiredService<ITextLocalizer>();
+    }
+
+    protected IDbConnection Connection => SqlConnections.NewByKey("Default");
+    protected ISqlDialect Dialect => Connection.GetDialect();
+}

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/ConcurrentSequenceAllocationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/ConcurrentSequenceAllocationTests.cs
@@ -25,7 +25,7 @@ public sealed class ConcurrentSequenceAllocationTests : IDisposable
     /// counter value (decimal here, but the pattern is identical for long).
     /// </summary>
     private sealed class SequenceRepository(ISqlConnections sqlConnections)
-        : RepositoryBase<IntegrationTestRow, int>(sqlConnections)
+        : RowRepositoryBase<IntegrationTestRow, int>(sqlConnections)
     {
         public Task<long> AllocateNextAsync(string sequenceKey, CancellationToken ct = default) =>
             InNewTransactionAsync(async (uow, token) =>

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/InNewTransactionAsyncTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/InNewTransactionAsyncTests.cs
@@ -17,7 +17,7 @@ public sealed class InNewTransactionAsyncTests : IDisposable
     private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
 
     private sealed class TestRepository(ISqlConnections sqlConnections)
-        : RepositoryBase<IntegrationTestRow, int>(sqlConnections)
+        : RowRepositoryBase<IntegrationTestRow, int>(sqlConnections)
     {
         public Task<int> CreateInNewTxAsync(IntegrationTestRow row, CancellationToken ct = default) =>
             InNewTransactionAsync(async (uow, token) =>

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/LockedTryFirstSqlServerTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/LockedTryFirstSqlServerTests.cs
@@ -18,7 +18,7 @@ public sealed class LockedTryFirstSqlServerTests : IDisposable
     private static readonly IntegrationTestRow.RowFields Fld = IntegrationTestRow.Fields;
 
     private sealed class TestRepository(ISqlConnections sqlConnections)
-        : RepositoryBase<IntegrationTestRow, int>(sqlConnections)
+        : RowRepositoryBase<IntegrationTestRow, int>(sqlConnections)
     {
         // Exposes protected InNewTransactionAsync to tests. In production,
         // consumers call InNewTransactionAsync from inside their own repo

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/OptimisticConcurrencyTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/OptimisticConcurrencyTests.cs
@@ -5,7 +5,7 @@ namespace Idevs.Net.CoreLib.Tests.Integration;
 
 /// <summary>
 /// Integration coverage for the <see cref="RowVersionAttribute"/>-driven
-/// optimistic-concurrency guard on <see cref="RepositoryBase{TRow,TKey}"/>'s
+/// optimistic-concurrency guard on <see cref="RowRepositoryBase{TRow,TKey}"/>'s
 /// three TRow-shaped UpdateAsync overloads. Verifies the happy path,
 /// the conflict-detection path, the manual retry loop, and confirms
 /// rows without [RowVersion] are unchanged from 0.7.7 behavior.
@@ -19,7 +19,7 @@ public sealed class OptimisticConcurrencyTests : IDisposable
     private static readonly VersionedTestRow.RowFields Fld = VersionedTestRow.Fields;
 
     private sealed class TestRepository(ISqlConnections sqlConnections)
-        : RepositoryBase<VersionedTestRow, int>(sqlConnections);
+        : RowRepositoryBase<VersionedTestRow, int>(sqlConnections);
 
     public OptimisticConcurrencyTests(MsSqlContainerFixture fixture)
     {
@@ -236,7 +236,7 @@ public sealed class OptimisticConcurrencyTests : IDisposable
         // behave exactly as in 0.7.7: no exception type changes, no
         // WHERE-RowVersion clause emitted. Quick sanity test against
         // the existing IntegrationTestRow infrastructure.
-        var unversionedRepo = new RepositoryBase<IntegrationTestRow, int>(_fixture.SqlConnections);
+        var unversionedRepo = new RowRepositoryBase<IntegrationTestRow, int>(_fixture.SqlConnections);
 
         var newId = (int)await unversionedRepo.CreateAsync(new IntegrationTestRow { Code = "Plain", Amount = 1m });
         var row = await unversionedRepo.GetByIdAsync(newId);

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/RawSqlHelperIntegrationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/RawSqlHelperIntegrationTests.cs
@@ -17,7 +17,7 @@ public sealed class RawSqlHelperIntegrationTests : IDisposable
     private readonly TestService _svc;
 
     /// <summary>Test subject — re-exposes the protected raw-SQL helpers.</summary>
-    private sealed class TestService : RepositoryBase<IntegrationTestRow, int>
+    private sealed class TestService : RowRepositoryBase<IntegrationTestRow, int>
     {
         public TestService(ISqlConnections c) : base(c) { }
 

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryCountExistsIntegrationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryCountExistsIntegrationTests.cs
@@ -19,7 +19,7 @@ public sealed class RepositoryCountExistsIntegrationTests : IDisposable
     private readonly TestRepository _repo;
 
     private sealed class TestRepository(ISqlConnections sqlConnections)
-        : RepositoryBase<IntegrationTestRow, int>(sqlConnections);
+        : RowRepositoryBase<IntegrationTestRow, int>(sqlConnections);
 
     public RepositoryCountExistsIntegrationTests(MsSqlContainerFixture fixture)
     {

--- a/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Integration/RepositoryWriteIntegrationTests.cs
@@ -17,7 +17,7 @@ public sealed class RepositoryWriteIntegrationTests : IDisposable
     private readonly TestRepository _repo;
 
     private sealed class TestRepository(ISqlConnections sqlConnections)
-        : RepositoryBase<IntegrationTestRow, int>(sqlConnections);
+        : RowRepositoryBase<IntegrationTestRow, int>(sqlConnections);
 
     public RepositoryWriteIntegrationTests(MsSqlContainerFixture fixture)
     {
@@ -308,7 +308,7 @@ public sealed class RepositoryWriteIntegrationTests : IDisposable
     }
 
     /// <summary>
-    /// And the cure: <see cref="RepositoryBase{TRow}.CreateExcludingAsync"/>
+    /// And the cure: <see cref="RowRepositoryBase{TRow}.CreateExcludingAsync"/>
     /// lets the caller drop the Expression field even when it was assigned.
     /// </summary>
     [Fact]
@@ -357,7 +357,7 @@ public sealed class RepositoryWriteIntegrationTests : IDisposable
 
     /// <summary>
     /// And the cure on the UPDATE path:
-    /// <see cref="RepositoryBase{TRow, TKey}.UpdateExcludingAsync"/> drops
+    /// <see cref="RowRepositoryBase{TRow, TKey}.UpdateExcludingAsync"/> drops
     /// the assigned Expression field before building the SET list.
     /// </summary>
     [Fact]

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/ObsoleteSyncWrapperTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/ObsoleteSyncWrapperTests.cs
@@ -5,10 +5,10 @@ namespace Idevs.Net.CoreLib.Tests.Repositories;
 public class ObsoleteSyncWrapperTests
 {
     [Theory]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow>), "First")]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow>), "List")]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow>), "GetBy")]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow>), "Create")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow>), "First")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow>), "List")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow>), "GetBy")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow>), "Create")]
     public void SyncWrapper_HasObsoleteAttribute(Type baseType, string methodName)
     {
         var method = baseType
@@ -20,10 +20,10 @@ public class ObsoleteSyncWrapperTests
     }
 
     [Theory]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow, int>), "GetById")]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow, int>), "GetByIds")]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow, int>), "Update")]
-    [InlineData(typeof(Idevs.Repositories.RepositoryBase<TestSampleRow, int>), "DeleteById")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow, int>), "GetById")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow, int>), "GetByIds")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow, int>), "Update")]
+    [InlineData(typeof(Idevs.Repositories.RowRepositoryBase<TestSampleRow, int>), "DeleteById")]
     public void TKeySyncWrapper_HasObsoleteAttribute(Type baseType, string methodName)
     {
         var method = baseType

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/RawSqlHelperTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/RawSqlHelperTests.cs
@@ -13,7 +13,7 @@ namespace Idevs.Net.CoreLib.Tests.Repositories;
 /// </summary>
 public class RawSqlHelperTests
 {
-    private sealed class TestService : Idevs.Repositories.RepositoryBase<TestSampleRow>
+    private sealed class TestService : Idevs.Repositories.RowRepositoryBase<TestSampleRow>
     {
         public int ExecuteAsyncCallCount { get; private set; }
         public IUnitOfWork? LastUow { get; private set; }

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/RowRepositoryBaseTKeyTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/RowRepositoryBaseTKeyTests.cs
@@ -4,9 +4,9 @@ using Serenity.Data;
 
 namespace Idevs.Net.CoreLib.Tests.Repositories;
 
-public class RepositoryBaseTKeyTests
+public class RowRepositoryBaseTKeyTests
 {
-    private sealed class CapturingRepo : Idevs.Repositories.RepositoryBase<TestSampleRow, int>
+    private sealed class CapturingRepo : Idevs.Repositories.RowRepositoryBase<TestSampleRow, int>
     {
         public int ExecuteAsyncCallCount { get; private set; }
         public IUnitOfWork? LastUow { get; private set; }

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/RowRepositoryBaseTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/RowRepositoryBaseTests.cs
@@ -4,11 +4,11 @@ using Serenity.Data;
 
 namespace Idevs.Net.CoreLib.Tests.Repositories;
 
-public class RepositoryBaseTests
+public class RowRepositoryBaseTests
 {
     // A test subject that overrides ExecuteAsync so we can verify dispatch
     // without depending on Serenity SQL extension methods over a mock connection.
-    private sealed class CapturingRepo : Idevs.Repositories.RepositoryBase<TestSampleRow>
+    private sealed class CapturingRepo : Idevs.Repositories.RowRepositoryBase<TestSampleRow>
     {
         public int ExecuteAsyncCallCount { get; private set; }
         public IUnitOfWork? LastUow { get; private set; }

--- a/tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs
+++ b/tests/Idevs.Net.CoreLib.Tests/Repositories/UnitOfWorkHelperTests.cs
@@ -10,7 +10,7 @@ public class UnitOfWorkHelperTests
     // Test subject that exposes BeginUnitOfWork / CommitOnSuccessAsync via a
     // public surface. Overriding ExecuteAsync isn't needed because the helpers
     // talk to UnitOfWork directly.
-    private sealed class TestService : Idevs.Repositories.RepositoryBase<TestSampleRow>
+    private sealed class TestService : Idevs.Repositories.RowRepositoryBase<TestSampleRow>
     {
         public TestService(ISqlConnections c) : base(c) { }
 


### PR DESCRIPTION
## Summary

- Rename `Idevs.Repositories.RepositoryBase<TRow>` / `<TRow, TKey>` → `RowRepositoryBase<TRow>` / `<TRow, TKey>`. Behaviour identical; only the type name changed.
- Re-introduce `Idevs.RepositoryBase<T>` (v0.3.3 plumbing-only base, `T` = `ILogger<T>` category) as an `[Obsolete]` legacy class so downstream projects on the v0.3.3 API (notably PowerACC) keep compiling during migration. Scheduled for removal in **v1.0**.
- PublicAPI tracking: `*REMOVED*` markers on the prior shipped entries + new shipped-shape entries on `RowRepositoryBase` + 12 entries for the legacy class.
- Docs: CHANGELOG entry for 0.7.9; MIGRATION section with before/after table, mechanical sed snippet, removal timeline; README current-state examples updated.

## Why

`RepositoryBase` carried two completely incompatible meanings across the v0.3.x and v0.6.x+ generations — same name, different generic parameter semantics (`T` = logger category vs. `TRow` = Serenity `IRow`), incompatible ctors (`IServiceProvider`/`ILogger<T>` vs. `ISqlConnections`). A subclass shim cannot bridge them. Renaming the typed-row variant removes the ambiguity, and restoring the v0.3.3 body verbatim under the original namespace lets downstream code that still calls `base(serviceProvider, logger)` keep compiling unchanged.

## Test plan

- [x] `dotnet build src/Idevs.Net.CoreLib/Idevs.Net.CoreLib.csproj -c Release` — 0 errors
- [x] `dotnet test tests/Idevs.Net.CoreLib.Tests --filter "FullyQualifiedName!~Integration"` — 146/146 pass on net8.0 and net10.0
- [ ] Integration tests (Testcontainers required) — run in CI
- [ ] Downstream smoke: import `0.7.9-*` preview into PowerACC, confirm `using Idevs;` consumers compile with only `[Obsolete]` warnings and `using Idevs.Repositories;` consumers compile after `RepositoryBase` → `RowRepositoryBase` rename

## Notes

- 25 files changed, 286 insertions, 62 deletions.
- File renames preserved via `git mv` (similarity 95-99% on the four renamed files).
- The 538 `RS0036` warnings are pre-existing nullable-annotation mismatches on shipped PublicAPI entries copied forward — same warnings existed before this PR.